### PR TITLE
MSK Connect fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.lenses</groupId>
     <artifactId>kafka-connect-smt</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
+++ b/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
@@ -11,6 +11,7 @@
 
 package io.lenses.connect.smt.header;
 
+import static io.lenses.connect.smt.header.Utils.isBlank;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
 
@@ -31,7 +32,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -411,7 +411,7 @@ public final class TimestampConverter<R extends ConnectRecord<R>> implements Tra
 
     final String unixPrecision = simpleConfig.getString(UNIX_PRECISION_CONFIG);
 
-    if (type.equals(TYPE_STRING) && Utils.isBlank(toFormatPattern)) {
+    if (type.equals(TYPE_STRING) && isBlank(toFormatPattern)) {
       throw new ConfigException(
           "TimestampConverter requires format option to be specified "
               + "when using string timestamps");
@@ -646,4 +646,6 @@ public final class TimestampConverter<R extends ConnectRecord<R>> implements Tra
   private SchemaAndValue convertTimestamp(Object timestamp) {
     return convertTimestamp(timestamp, null);
   }
+
+
 }

--- a/src/main/java/io/lenses/connect/smt/header/Utils.java
+++ b/src/main/java/io/lenses/connect/smt/header/Utils.java
@@ -36,4 +36,8 @@ class Utils {
     }
     return format;
   }
+
+  public static boolean isBlank(String str) {
+    return str == null || str.trim().isEmpty();
+  }
 }


### PR DESCRIPTION
On MSK Connect org.apache.kafka.common.utils.Utils.isBlank is raising an exception since it cannot be found. This might result of an older Kafka used on MSK or the class being modified internally by the AWS team for their distribution.

The code change brings the method inside the lib to avoid the issue found.