### PR TITLE
Add Support for String Representation of Epoch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.lenses</groupId>
     <artifactId>kafka-connect-smt</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingWallclock.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingWallclock.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.time.Instant;

--- a/src/main/java/io/lenses/connect/smt/header/InsertWallclock.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertWallclock.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.time.Instant;

--- a/src/main/java/io/lenses/connect/smt/header/InsertWallclockDateTimePart.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertWallclockDateTimePart.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.time.Instant;

--- a/src/main/java/io/lenses/connect/smt/header/RollingWindow.java
+++ b/src/main/java/io/lenses/connect/smt/header/RollingWindow.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 enum RollingWindow {

--- a/src/main/java/io/lenses/connect/smt/header/RollingWindowDetails.java
+++ b/src/main/java/io/lenses/connect/smt/header/RollingWindowDetails.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.time.Instant;

--- a/src/main/java/io/lenses/connect/smt/header/RollingWindowUtils.java
+++ b/src/main/java/io/lenses/connect/smt/header/RollingWindowUtils.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.util.Locale;

--- a/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
+++ b/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import static io.lenses.connect.smt.header.Utils.isBlank;
@@ -662,6 +661,4 @@ public final class TimestampConverter<R extends ConnectRecord<R>> implements Tra
   private SchemaAndValue convertTimestamp(Object timestamp) {
     return convertTimestamp(timestamp, null);
   }
-
-
 }

--- a/src/main/java/io/lenses/connect/smt/header/Utils.java
+++ b/src/main/java/io/lenses/connect/smt/header/Utils.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import java.time.format.DateTimeFormatter;

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingWallclockTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingWallclockTest.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/lenses/connect/smt/header/InsertWallclockDateTimePartTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertWallclockDateTimePartTest.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/lenses/connect/smt/header/InsertWallclockTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertWallclockTest.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
@@ -262,6 +262,22 @@ public class TimestampConverterTest {
   }
 
   @Test
+  public void testSchemalessUnixAsStringToTimestamp() {
+    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
+    Map<String, String> config = new HashMap<>();
+    config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
+    config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+    transformer.configure(config);
+    String datePlusTimeUnixString = String.valueOf(DATE_PLUS_TIME_UNIX);
+    SourceRecord transformed = transformer.apply(createRecordSchemaless(datePlusTimeUnixString));
+
+    Header header = transformed.headers().lastWithName("ts_header");
+    assertNotNull(header);
+    assertEquals(Timestamp.SCHEMA.type(), header.schema().type());
+    assertEquals(DATE_PLUS_TIME.getTime(), header.value());
+  }
+
+  @Test
   public void testSchemalessStringToTimestamp() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");

--- a/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
@@ -8,7 +8,6 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  * for the specific language governing permissions and limitations under the License.
  */
-
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -119,10 +118,10 @@ public class TimestampConverterTest {
 
   @Test
   public void testConfigMissingFormat() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     assertThrows(ConfigException.class, () -> transformer.configure(config));
   }
 
@@ -140,10 +139,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessIdentity() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME.getTime()));
 
@@ -155,10 +155,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessTimestampToDate() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME.getTime()));
 
@@ -170,10 +171,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessTimestampToTime() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME.getTime()));
 
@@ -185,10 +187,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessTimestampToUnix() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME.getTime()));
 
@@ -218,10 +221,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessDateToTimestamp() {
-    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE.getTime()));
 
@@ -233,10 +237,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessTimeToTimestamp() {
-    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(TIME.getTime()));
 
@@ -248,10 +253,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testSchemalessUnixToTimestamp() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME_UNIX));
 
@@ -262,7 +268,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessUnixAsStringToTimestamp() {
+  void testSchemalessUnixAsStringToTimestamp() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -329,10 +335,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testWithSchemaTimestampToTime() {
-    TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "tm_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed =
         transformer.apply(createRecordWithSchema(Timestamp.SCHEMA, DATE_PLUS_TIME.getTime()));
@@ -345,10 +352,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testWithSchemaTimestampToUnix() {
-    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "unix_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed =
         transformer.apply(createRecordWithSchema(Timestamp.SCHEMA, DATE_PLUS_TIME.getTime()));
@@ -443,10 +451,11 @@ public class TimestampConverterTest {
 
   @Test
   public void testWithSchemaDateToTimestamp() {
-    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
+
+    final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed =
         transformer.apply(createRecordWithSchema(Date.SCHEMA, DATE.getTime()));

--- a/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
@@ -81,14 +81,14 @@ public class TimestampConverterTest {
   // Configuration
 
   @Test
-  public void testConfigNoTargetType() {
+  void testConfigNoTargetType() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     assertThrows(
         ConfigException.class, () -> transformer.configure(Collections.<String, String>emptyMap()));
   }
 
   @Test
-  public void testConfigInvalidTargetType() {
+  void testConfigInvalidTargetType() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     assertThrows(
         ConfigException.class,
@@ -98,7 +98,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigInvalidUnixPrecision() {
+  void testConfigInvalidUnixPrecision() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "invalid");
@@ -107,7 +107,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigValidUnixPrecision() {
+  void testConfigValidUnixPrecision() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "seconds");
@@ -117,7 +117,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigMissingFormat() {
+  void testConfigMissingFormat() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -126,7 +126,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigInvalidFormat() {
+  void testConfigInvalidFormat() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, "bad-format");
@@ -138,7 +138,7 @@ public class TimestampConverterTest {
   // Conversions without schemas (most flexible Timestamp -> other types)
 
   @Test
-  public void testSchemalessIdentity() {
+  void testSchemalessIdentity() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -154,7 +154,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToDate() {
+  void testSchemalessTimestampToDate() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -170,7 +170,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToTime() {
+  void testSchemalessTimestampToTime() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -186,7 +186,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToUnix() {
+  void testSchemalessTimestampToUnix() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -202,7 +202,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToString() {
+  void testSchemalessTimestampToString() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, STRING_DATE_FMT);
@@ -220,7 +220,7 @@ public class TimestampConverterTest {
   // Conversions without schemas (core types -> most flexible Timestamp format)
 
   @Test
-  public void testSchemalessDateToTimestamp() {
+  void testSchemalessDateToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -236,7 +236,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimeToTimestamp() {
+  void testSchemalessTimeToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -252,7 +252,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessUnixToTimestamp() {
+  void testSchemalessUnixToTimestamp() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -284,7 +284,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToTimestamp() {
+  void testSchemalessStringToTimestamp() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FORMAT_FROM_CONFIG, STRING_DATE_FMT);
@@ -302,7 +302,7 @@ public class TimestampConverterTest {
   // Conversions with schemas (most flexible Timestamp -> other types)
 
   @Test
-  public void testWithSchemaIdentity() {
+  void testWithSchemaIdentity() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -318,7 +318,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToDate() {
+  void testWithSchemaTimestampToDate() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
@@ -334,7 +334,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToTime() {
+  void testWithSchemaTimestampToTime() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "tm_header");
@@ -351,7 +351,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToUnix() {
+  void testWithSchemaTimestampToUnix() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "unix_header");
@@ -368,7 +368,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToString() {
+  void testWithSchemaTimestampToString() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, STRING_DATE_FMT);
@@ -387,31 +387,31 @@ public class TimestampConverterTest {
   // Null-value conversions schemaless
 
   @Test
-  public void testSchemalessNullValueToString() {
+  void testSchemalessNullValueToString() {
     testSchemalessNullValueConversion("string");
     testSchemalessNullFieldConversion("string");
   }
 
   @Test
-  public void testSchemalessNullValueToDate() {
+  void testSchemalessNullValueToDate() {
     testSchemalessNullValueConversion("Date");
     testSchemalessNullFieldConversion("Date");
   }
 
   @Test
-  public void testSchemalessNullValueToTimestamp() {
+  void testSchemalessNullValueToTimestamp() {
     testSchemalessNullValueConversion("Timestamp");
     testSchemalessNullFieldConversion("Timestamp");
   }
 
   @Test
-  public void testSchemalessNullValueToUnix() {
+  void testSchemalessNullValueToUnix() {
     testSchemalessNullValueConversion("unix");
     testSchemalessNullFieldConversion("unix");
   }
 
   @Test
-  public void testSchemalessNullValueToTime() {
+  void testSchemalessNullValueToTime() {
     testSchemalessNullValueConversion("Time");
     testSchemalessNullFieldConversion("Time");
   }
@@ -450,7 +450,7 @@ public class TimestampConverterTest {
   // Conversions with schemas (core types -> most flexible Timestamp format)
 
   @Test
-  public void testWithSchemaDateToTimestamp() {
+  void testWithSchemaDateToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -467,7 +467,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimeToTimestamp() {
+  void testWithSchemaTimeToTimestamp() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -483,7 +483,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaUnixToTimestamp() {
+  void testWithSchemaUnixToTimestamp() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -499,7 +499,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaStringToTimestamp() {
+  void testWithSchemaStringToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FORMAT_FROM_CONFIG, STRING_DATE_FMT);
@@ -518,7 +518,7 @@ public class TimestampConverterTest {
   // Null-value conversions with schema
 
   @Test
-  public void testWithSchemaNullValueToTimestamp() {
+  void testWithSchemaNullValueToTimestamp() {
     testWithSchemaNullValueConversion(
         "Timestamp", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -538,7 +538,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToTimestamp() {
+  void testWithSchemaNullFieldToTimestamp() {
     testWithSchemaNullFieldConversion(
         "Timestamp", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -558,7 +558,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToUnix() {
+  void testWithSchemaNullValueToUnix() {
     testWithSchemaNullValueConversion(
         "unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -572,7 +572,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToUnix() {
+  void testWithSchemaNullFieldToUnix() {
     testWithSchemaNullFieldConversion(
         "unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -586,7 +586,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToTime() {
+  void testWithSchemaNullValueToTime() {
     testWithSchemaNullValueConversion(
         "Time", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -602,7 +602,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToTime() {
+  void testWithSchemaNullFieldToTime() {
     testWithSchemaNullFieldConversion(
         "Time", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -618,7 +618,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToDate() {
+  void testWithSchemaNullValueToDate() {
     testWithSchemaNullValueConversion(
         "Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -634,7 +634,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToDate() {
+  void testWithSchemaNullFieldToDate() {
     testWithSchemaNullFieldConversion(
         "Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -650,7 +650,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToString() {
+  void testWithSchemaNullValueToString() {
     testWithSchemaNullValueConversion(
         "string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -664,7 +664,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToString() {
+  void testWithSchemaNullFieldToString() {
     testWithSchemaNullFieldConversion(
         "string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -730,7 +730,7 @@ public class TimestampConverterTest {
   // Convert field instead of entire key/value
 
   @Test
-  public void testSchemalessFieldConversion() {
+  void testSchemalessFieldConversion() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -748,7 +748,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion() {
+  void testWithSchemaFieldConversion() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -776,7 +776,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Micros() {
+  void testWithSchemaFieldConversion_Micros() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -801,7 +801,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Nanos() {
+  void testWithSchemaFieldConversion_Nanos() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -826,7 +826,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Seconds() {
+  void testWithSchemaFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -855,7 +855,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaValuePrefixedFieldConversion_Seconds() {
+  void testWithSchemaValuePrefixedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_value.ts");
@@ -884,7 +884,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaKeyPrefixedFieldConversion_Seconds() {
+  void testWithSchemaKeyPrefixedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.ts");
@@ -915,7 +915,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedFieldConversion_Seconds() {
+  void testWithSchemaNestedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "level1.ts");
@@ -948,7 +948,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion_Seconds() {
+  void testWithSchemaNestedKeyFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -983,7 +983,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Micros() {
+  void testSchemalessStringToUnix_Micros() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "microseconds");
@@ -1000,7 +1000,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Nanos() {
+  void testSchemalessStringToUnix_Nanos() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "nanoseconds");
@@ -1017,7 +1017,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Seconds() {
+  void testSchemalessStringToUnix_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "seconds");
@@ -1036,7 +1036,7 @@ public class TimestampConverterTest {
   // Validate Key implementation in addition to Value
 
   @Test
-  public void testKey() {
+  void testKey() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key");
@@ -1054,7 +1054,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion15SecondsWindow() {
+  void testWithSchemaNestedKeyFieldConversion15SecondsWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -1092,7 +1092,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursTimestampWindow() {
+  void testWithSchemaNestedKeyFieldConversion2HoursTimestampWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -1130,7 +1130,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursStringWindow() {
+  void testWithSchemaNestedKeyFieldConversion2HoursStringWindow() {
 
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
@@ -1172,7 +1172,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursStringWindowWhenSourceIsString() {
+  void testWithSchemaNestedKeyFieldConversion2HoursStringWindowWhenSourceIsString() {
 
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
@@ -1214,7 +1214,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion10MinutesWindow() {
+  void testWithSchemaNestedKeyFieldConversion10MinutesWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");


### PR DESCRIPTION
In some cases, epoch values are stored as strings. This commit enhances compatibility by introducing support for string representations. The inference mechanism now includes checks to parse string inputs to long values. Additionally, the UNIX translator has been updated to accommodate string inputs.

These changes ensure seamless handling of epoch values in both numerical and string formats.