### PR TITLE
Simplify S3/Azure/GCS Sink Configuration

### DIFF
--- a/InsertRecordTimestampHeaders.md
+++ b/InsertRecordTimestampHeaders.md
@@ -1,0 +1,101 @@
+# Insert Wallclock
+
+## Description
+
+A Kafka Connect Single Message Transform (SMT) that inserts date, year, month,day, hour, minute and second headers using
+the record timestamp. If the record timestamp is null, the SMT uses the current system time.
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _date, _hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _year, _month, _day, _hour
+```
+
+## Configuration
+
+| Name                 | Description                                                     | Type   | Default    | Importance |
+|----------------------|-----------------------------------------------------------------|--------|------------|------------|
+| `header.prefix.name` | Optional header prefix.                                         | String |            | Low        |
+| `date.format`        | Optional Java date time formatter.                              | String | yyyy-MM-dd | Low        |
+| `year.format`        | Optional Java date time formatter for the year component.       | String | yyyy       | Low        |
+| `month.format`       | Optional Java date time formatter for the month component.      | String | MM         | Low        |
+| `day.format`         | Optional Java date time formatter for the day component.        | String | dd         | Low        |
+| `hour.format`        | Optional Java date time formatter for the hour component.       | String | HH         | Low        |
+| `minute.format`      | Optional Java date time formatter for the minute component.     | String | mm         | Low        |
+| `second.format`      | Optional Java date time formatter for the second component.     | String | ss         | Low        |
+| `timezone`           | Optional. Sets the timezone. It can be any valid Java timezone. | String | UTC        | Low        |
+| `locale`             | Optional. Sets the locale. It can be any valid Java locale.     | String | en         | Low        |
+
+## Example
+
+To store the epoch value, use the following configuration:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.header.prefix.name=wallclock_
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.date.format=yyyy-MM-dd
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.timezone=Asia/Kolkata
+```
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders    
+transforms.InsertWallclock.date.format="date=yyyy-MM-dd"
+transforms.InsertWallclock.hour.format="hour=yyyy"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY date, year
+```

--- a/InsertRollingRecordTimestampHeaders.md
+++ b/InsertRollingRecordTimestampHeaders.md
@@ -1,0 +1,118 @@
+# Insert Wallclock
+
+## Description
+
+A Kafka Connect Single Message Transform (SMT) that inserts date, year, month,day, hour, minute and second headers using
+the record timestamp and a rolling time window configuration. If the record timestamp is null, the SMT uses the current
+system time.
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _date, _hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _year, _month, _day, _hour
+```
+
+## Configuration
+
+| Name                  | Description                                                                                                                                                   | Type   | Default    | Importance              |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|------------|-------------------------|
+| `header.prefix.name`  | Optional header prefix.                                                                                                                                       | String |            | Low                     |
+| `date.format`         | Optional Java date time formatter.                                                                                                                            | String | yyyy-MM-dd | Low                     |
+| `year.format`         | Optional Java date time formatter for the year component.                                                                                                     | String | yyyy       | Low                     |
+| `month.format`        | Optional Java date time formatter for the month component.                                                                                                    | String | MM         | Low                     |
+| `day.format`          | Optional Java date time formatter for the day component.                                                                                                      | String | dd         | Low                     |
+| `hour.format`         | Optional Java date time formatter for the hour component.                                                                                                     | String | HH         | Low                     |
+| `minute.format`       | Optional Java date time formatter for the minute component.                                                                                                   | String | mm         | Low                     |
+| `second.format`       | Optional Java date time formatter for the second component.                                                                                                   | String | ss         | Low                     |
+| `timezone`            | Optional. Sets the timezone. It can be any valid Java timezone.                                                                                               | String | UTC        | Low                     |
+| `locale`              | Optional. Sets the locale. It can be any valid Java locale.                                                                                                   | String | en         | Low                     |
+| `rolling.window.type` | Sets the window type. It can be fixed or rolling.                                                                                                             | String | minutes    | hours, minutes, seconds | High       | 
+| `rolling.window.size` | Sets the window size. It can be any positive integer, and depending on the `window.type` it has an upper bound, 60 for seconds and minutes, and 24 for hours. | Int    | 15         |                         | High       |
+
+## Example
+
+To store the epoch value, use the following configuration:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingRecordTimestampHeaders
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingRecordTimestampHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingRecordTimestampHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingRecordTimestampHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+```
+
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingRecordTimestampHeaders
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+transforms.rollingWindow.hour.format="hour=yyyy"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY date, year
+```

--- a/InsertRollingWallclockHeaders.md
+++ b/InsertRollingWallclockHeaders.md
@@ -1,0 +1,117 @@
+# Insert Wallclock
+
+## Description
+
+A Kafka Connect Single Message Transform (SMT) that inserts date, year, month,day, hour, minute and second headers using
+the system timestamp and a rolling time window configuration.  
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _date, _hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _year, _month, _day, _hour
+```
+
+## Configuration
+
+| Name                  | Description                                                                                                                                                   | Type   | Default    | Importance              |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|------------|-------------------------|
+| `header.prefix.name`  | Optional header prefix.                                                                                                                                       | String |            | Low                     |
+| `date.format`         | Optional Java date time formatter.                                                                                                                            | String | yyyy-MM-dd | Low                     |
+| `year.format`         | Optional Java date time formatter for the year component.                                                                                                     | String | yyyy       | Low                     |
+| `month.format`        | Optional Java date time formatter for the month component.                                                                                                    | String | MM         | Low                     |
+| `day.format`          | Optional Java date time formatter for the day component.                                                                                                      | String | dd         | Low                     |
+| `hour.format`         | Optional Java date time formatter for the hour component.                                                                                                     | String | HH         | Low                     |
+| `minute.format`       | Optional Java date time formatter for the minute component.                                                                                                   | String | mm         | Low                     |
+| `second.format`       | Optional Java date time formatter for the second component.                                                                                                   | String | ss         | Low                     |
+| `timezone`            | Optional. Sets the timezone. It can be any valid Java timezone.                                                                                               | String | UTC        | Low                     |
+| `locale`              | Optional. Sets the locale. It can be any valid Java locale.                                                                                                   | String | en         | Low                     |
+| `rolling.window.type` | Sets the window type. It can be fixed or rolling.                                                                                                             | String | minutes    | hours, minutes, seconds | High       | 
+| `rolling.window.size` | Sets the window size. It can be any positive integer, and depending on the `window.type` it has an upper bound, 60 for seconds and minutes, and 24 for hours. | Int    | 15         |                         | High       |
+
+## Example
+
+To store the epoch value, use the following configuration:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingWallclockHeaders
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingWallclockHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingWallclockHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingWallclockHeaders
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+```
+
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingWallclockHeaders
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+transforms.rollingWindow.hour.format="hour=yyyy"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY date, year
+```

--- a/InsertWallclock.md
+++ b/InsertWallclock.md
@@ -2,6 +2,11 @@
 
 ## Description
 
+> **Note:** Use [InsertWallclockHeaders](./InsertWallclockHeaders.md) SMT if you want to use more than one date time
+> part. This avoids multiple SMTs and is more efficient. For example if you want to partition the data
+> by `yyyy-MM-dd/HH`,
+> then you can use `InsertWallclockHeaders` which inserts multiple headers: date, year, month,day, hour, minute, second.
+>
 A Kafka Connect Single Message Transform (SMT) that inserts the system clock as a message header.
 
 Inserts the system clock as a message header, with a value of type STRING. The value can be either a string

--- a/InsertWallclockDateTimePart.md
+++ b/InsertWallclockDateTimePart.md
@@ -2,6 +2,9 @@
 
 ## Description
 
+> **Note:** Use [InsertWallclockHeaders](./InsertWallclockHeaders.md) SMT if you want to use more than one date time
+> part. This avoids multiple SMTs and is more efficient.
+>
 A Kafka Connect Single Message Transform (SMT) that inserts the system clock year, month, day, minute, or seconds as a
 message header, with a value of type STRING.
 
@@ -50,6 +53,7 @@ transforms.InsertWallclockDateTimePart.type=io.lenses.connect.smt.header.InsertW
 transforms.InsertWallclockDateTimePart.header.name=wallclock
 transforms.InsertWallclockDateTimePart.date.time.part=hour
 ```
+
 To store the hour, and apply a timezone, use the following configuration:
 
 ```properties

--- a/InsertWallclockHeaders.md
+++ b/InsertWallclockHeaders.md
@@ -1,0 +1,101 @@
+# Insert Wallclock
+
+## Description
+
+A Kafka Connect Single Message Transform (SMT) that inserts date, year, month,day, hour, minute and second headers using
+the system clock as a message header.
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _date, _hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _year, _month, _day, _hour
+```
+
+## Configuration
+
+| Name                 | Description                                                     | Type   | Default    | Importance |
+|----------------------|-----------------------------------------------------------------|--------|------------|------------|
+| `header.prefix.name` | Optional header prefix.                                         | String |            | Low        |
+| `date.format`        | Optional Java date time formatter.                              | String | yyyy-MM-dd | Low        |
+| `year.format`        | Optional Java date time formatter for the year component.       | String | yyyy       | Low        |
+| `month.format`       | Optional Java date time formatter for the month component.      | String | MM         | Low        |
+| `day.format`         | Optional Java date time formatter for the day component.        | String | dd         | Low        |
+| `hour.format`        | Optional Java date time formatter for the hour component.       | String | HH         | Low        |
+| `minute.format`      | Optional Java date time formatter for the minute component.     | String | mm         | Low        |
+| `second.format`      | Optional Java date time formatter for the second component.     | String | ss         | Low        |
+| `timezone`           | Optional. Sets the timezone. It can be any valid Java timezone. | String | UTC        | Low        |
+| `locale`             | Optional. Sets the locale. It can be any valid Java locale.     | String | en         | Low        |
+
+## Example
+
+To store the epoch value, use the following configuration:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.header.prefix.name=wallclock_
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.date.format=yyyy-MM-dd
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.timezone=Asia/Kolkata
+```
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=InsertWallclock
+transforms.InsertWallclock.type=io.lenses.connect.smt.header.InsertWallclockHeaders
+transforms.InsertWallclock.date.format="date=yyyy-MM-dd"
+transforms.InsertWallclock.hour.format="hour=HH"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY date, year
+```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Furthermore, they support [Stream-Reactor](https://github.com/lensesio/stream-re
 
 * [InsertWallclock](./InsertWallclock.md) - Inserts the system clock as a message header.
 * [InsertRollingWallclock](./InsertRollingWallclock.md) - Inserts the system clock as a message header based on a rolling window boundary.
+* [InsertRollingRecordTimestampHeaders](./InsertRollingRecordTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the record timestamp and a rolling time window configuration.
+* [InsertRollingWallclockHeaders](./InsertRollingWallclockHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the system timestamp and a rolling time window configuration.
+* [InsertRecordTimestampHeaders](./InsertRecordTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the record timestamp.
+* [InsertWallclockHeaders](./InsertWallclockHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the system clock.
 * [TimestampConverter](./TimestampConverter.md) - Converts a timestamp field in the payload, record Key or Value to a different format, and optionally applies a rolling window boundary. An adapted version of the one packed in the Kafka Connect framework.
 * [InsertWallclockDateTimePart](./InsertWallclockDateTimePart.md) - Inserts the system clock year, month, day, minute, or seconds as a message header, with a value of type STRING.
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.lenses</groupId>
     <artifactId>kafka-connect-smt</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/io/lenses/connect/smt/header/InsertRecordTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRecordTimestampHeaders.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A transformer which takes the system time (wall-clock) and inserts a header year, month, day,
+ * hour, minute, second and day. The benefit over the InsertField SMT is that the payload is not
+ * modified leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+public class InsertRecordTimestampHeaders<R extends ConnectRecord<R>>
+    extends InsertTimestampHeaders<R> {
+
+  protected InsertRecordTimestampHeaders() {
+    super(InsertRecordTimestampHeaders.CONFIG_DEF);
+  }
+
+  @Override
+  protected Instant getInstant(R r) {
+    return r.timestamp() == null ? Instant.now() : Instant.ofEpochMilli(r.timestamp());
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingRecordTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingRecordTimestampHeaders.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A transformer which takes the record timestamp and inserts a header year, month, day, hour,
+ * minute, second and day. The benefit over the InsertField SMT is that the payload is not modified
+ * leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+class InsertRollingRecordTimestampHeaders<R extends ConnectRecord<R>>
+    extends InsertRollingTimestampHeaders<R> {
+
+  @Override
+  protected Instant getInstantInternal(R r) {
+    return r.timestamp() == null ? Instant.now() : Instant.ofEpochMilli(r.timestamp());
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingTimestampHeaders.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import java.util.Collections;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * A transformer which takes the record timestamp and inserts a header year, month, day, hour,
+ * minute, second and day. The benefit over the InsertField SMT is that the payload is not modified
+ * leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+abstract class InsertRollingTimestampHeaders<R extends ConnectRecord<R>>
+    extends InsertTimestampHeaders<R> {
+
+  public static ConfigDef CONFIG_DEF =
+      InsertTimestampHeaders.CONFIG_DEF
+          .define(
+              ConfigName.ROLLING_WINDOW_SIZE_CONFIG,
+              ConfigDef.Type.INT,
+              ConfigName.DEFAULT_ROLLING_WINDOW_VALUE,
+              ConfigDef.Importance.HIGH,
+              "The rolling window size. For example, if the rolling window is set to 'minutes' "
+                  + "and the rolling window value is set to 15, then the rolling window "
+                  + "is 15 minutes.")
+          .define(
+              ConfigName.ROLLING_WINDOW_TYPE_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_ROLLING_WINDOW.name(),
+              ConfigDef.Importance.HIGH,
+              "The rolling window type. The allowed values are hours, minutes or seconds.");
+  private RollingWindowDetails rollingWindowDetails;
+
+  protected InsertRollingTimestampHeaders() {
+    super(CONFIG_DEF);
+  }
+
+  interface ConfigName {
+    String ROLLING_WINDOW_TYPE_CONFIG = "rolling.window.type";
+    String ROLLING_WINDOW_SIZE_CONFIG = "rolling.window.size";
+
+    int DEFAULT_ROLLING_WINDOW_VALUE = 15;
+    RollingWindow DEFAULT_ROLLING_WINDOW = RollingWindow.MINUTES;
+  }
+
+  protected abstract Instant getInstantInternal(R r);
+
+  @Override
+  protected Instant getInstant(R r) {
+    return rollingWindowDetails.adjust(getInstantInternal(r));
+  }
+
+  @Override
+  protected void configureInternal(SimpleConfig config) {
+    final RollingWindow rollingWindow =
+        RollingWindowUtils.extractRollingWindow(
+                config, ConfigName.ROLLING_WINDOW_TYPE_CONFIG, Collections.emptySet())
+            .orElseThrow(
+                () ->
+                    new ConfigException(
+                        "Configuration '"
+                            + ConfigName.ROLLING_WINDOW_TYPE_CONFIG
+                            + "' must be set."));
+
+    final int rollingWindowSize =
+        RollingWindowUtils.extractRollingWindowSize(
+                config, rollingWindow, ConfigName.ROLLING_WINDOW_SIZE_CONFIG)
+            .orElseThrow(
+                () ->
+                    new ConfigException(
+                        "Configuration '"
+                            + ConfigName.ROLLING_WINDOW_SIZE_CONFIG
+                            + "' must be set."));
+
+    this.rollingWindowDetails = new RollingWindowDetails(rollingWindow, rollingWindowSize);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingWallclockHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingWallclockHeaders.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A transformer which takes the record timestamp and inserts a header year, month, day, hour,
+ * minute, second and day. The benefit over the InsertField SMT is that the payload is not modified
+ * leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+class InsertRollingWallclockHeaders<R extends ConnectRecord<R>>
+    extends InsertRollingTimestampHeaders<R> {
+
+  private Supplier<Instant> supplier = Instant::now;
+
+  // used solely for testing purposes
+  void setInstantSupplier(Supplier<Instant> supplier) {
+    this.supplier = supplier;
+  }
+
+  @Override
+  protected Instant getInstantInternal(R r) {
+    return supplier.get();
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertTimestampHeaders.java
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * A transformer which takes the record timestamp and inserts a header year, month, day, hour,
+ * minute, second and day. The benefit over the InsertField SMT is that the payload is not modified
+ * leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+abstract class InsertTimestampHeaders<R extends ConnectRecord<R>> implements Transformation<R> {
+
+  private DateTimeFormatter yearFormat;
+  private DateTimeFormatter monthFormat;
+  private DateTimeFormatter dayFormat;
+  private DateTimeFormatter hourFormat;
+  private DateTimeFormatter minuteFormat;
+  private DateTimeFormatter secondFormat;
+  private DateTimeFormatter dateFormat;
+  private String yearHeader;
+  private String monthHeader;
+  private String dayHeader;
+  private String hourHeader;
+  private String minuteHeader;
+  private String secondHeader;
+  private String dateHeader;
+
+  private ZoneId timeZone = ZoneId.of("UTC");
+
+  private final ConfigDef configDef;
+  public static ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              ConfigName.HEADER_PREFIX_NAME,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_PREFIX_NAME,
+              ConfigDef.Importance.HIGH,
+              "The prefix to use for the headers inserted. For example, if the prefix is 'wallclock_', the headers inserted will be 'wallclock_year', 'wallclock_month', etc.")
+          .define(
+              ConfigName.YEAR_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_YEAR_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the year. The default is '"
+                  + ConfigName.DEFAULT_YEAR_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.MONTH_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_MONTH_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the month. The default is '"
+                  + ConfigName.DEFAULT_MONTH_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.DAY_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_DAY_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the day. The default is '"
+                  + ConfigName.DEFAULT_DAY_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.HOUR_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_HOUR_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the hour. The default is '"
+                  + ConfigName.DEFAULT_HOUR_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.MINUTE_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_MINUTE_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the minute. The default is '"
+                  + ConfigName.DEFAULT_MINUTE_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.SECOND_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_SECOND_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the second. The default is '"
+                  + ConfigName.DEFAULT_SECOND_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.DATE_FORMAT_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_DATE_FORMAT,
+              ConfigDef.Importance.HIGH,
+              "The format to use for the date. The default is '"
+                  + ConfigName.DEFAULT_DATE_FORMAT
+                  + "'.")
+          .define(
+              ConfigName.TIMEZONE,
+              ConfigDef.Type.STRING,
+              "UTC",
+              ConfigDef.Importance.HIGH,
+              "The timezone to use.")
+          .define(
+              ConfigName.LOCALE,
+              ConfigDef.Type.STRING,
+              ConfigName.DEFAULT_LOCALE,
+              ConfigDef.Importance.HIGH,
+              "The locale to use.");
+
+  interface ConfigName {
+    String HEADER_PREFIX_NAME = "header.prefix.name";
+
+    String DATE_FORMAT_CONFIG = "date.format";
+    String YEAR_FORMAT_CONFIG = "year.format";
+    String MONTH_FORMAT_CONFIG = "month.format";
+    String DAY_FORMAT_CONFIG = "day.format";
+    String HOUR_FORMAT_CONFIG = "hour.format";
+    String MINUTE_FORMAT_CONFIG = "minute.format";
+    String SECOND_FORMAT_CONFIG = "second.format";
+
+    String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
+    String DEFAULT_YEAR_FORMAT = "yyyy";
+    String DEFAULT_MONTH_FORMAT = "MM";
+    String DEFAULT_DAY_FORMAT = "dd";
+    String DEFAULT_HOUR_FORMAT = "HH";
+    String DEFAULT_MINUTE_FORMAT = "mm";
+    String DEFAULT_SECOND_FORMAT = "ss";
+    String DEFAULT_PREFIX_NAME = "";
+
+    String TIMEZONE = "timezone";
+
+    String LOCALE = "locale";
+    String DEFAULT_LOCALE = "en";
+  }
+
+  protected InsertTimestampHeaders(ConfigDef configDef) {
+    this.configDef = configDef;
+  }
+
+  protected abstract Instant getInstant(R r);
+
+  @Override
+  public R apply(R r) {
+    if (r == null) {
+      return null;
+    }
+
+    // instant from epoch
+    final Instant now = getInstant(r);
+    final ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(now, timeZone);
+    r.headers().addString(yearHeader, yearFormat.format(zonedDateTime));
+    r.headers().addString(monthHeader, monthFormat.format(zonedDateTime));
+    r.headers().addString(dayHeader, dayFormat.format(zonedDateTime));
+    r.headers().addString(hourHeader, hourFormat.format(zonedDateTime));
+    r.headers().addString(minuteHeader, minuteFormat.format(zonedDateTime));
+    r.headers().addString(secondHeader, secondFormat.format(zonedDateTime));
+    r.headers().addString(dateHeader, dateFormat.format(zonedDateTime));
+    return r;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {}
+
+  protected void configureInternal(SimpleConfig config) {}
+
+  @Override
+  public void configure(Map<String, ?> props) {
+    final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+    final String timeZoneStr = config.getString(ConfigName.TIMEZONE);
+    timeZone = TimeZone.getTimeZone(timeZoneStr).toZoneId();
+    String prefixName = config.getString(ConfigName.HEADER_PREFIX_NAME);
+    yearHeader = prefixName + "year";
+    monthHeader = prefixName + "month";
+    dayHeader = prefixName + "day";
+    hourHeader = prefixName + "hour";
+    minuteHeader = prefixName + "minute";
+    secondHeader = prefixName + "second";
+    dateHeader = prefixName + "date";
+    Locale locale = new Locale(config.getString(ConfigName.LOCALE));
+    yearFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.YEAR_FORMAT_CONFIG),
+                ConfigName.YEAR_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    monthFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.MONTH_FORMAT_CONFIG),
+                ConfigName.MONTH_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    dayFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.DAY_FORMAT_CONFIG),
+                ConfigName.DAY_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    hourFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.HOUR_FORMAT_CONFIG),
+                ConfigName.HOUR_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    minuteFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.MINUTE_FORMAT_CONFIG),
+                ConfigName.MINUTE_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    secondFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.SECOND_FORMAT_CONFIG),
+                ConfigName.SECOND_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    dateFormat =
+        createDateTimeFormatter(
+                config.getString(ConfigName.DATE_FORMAT_CONFIG),
+                ConfigName.DATE_FORMAT_CONFIG,
+                locale)
+            .withZone(timeZone);
+    configureInternal(config);
+  }
+
+  private static DateTimeFormatter createDateTimeFormatter(
+      String patternConfig, String configName, Locale locale) {
+    try {
+      return DateTimeFormatter.ofPattern(patternConfig, locale);
+    } catch (IllegalArgumentException e) {
+      throw new ConfigException("Configuration '" + configName + "' is not a valid date format.");
+    }
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertWallclockHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertWallclockHeaders.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A transformer which takes the system time (wall-clock) and inserts a header year, month, day,
+ * hour, minute, second and day. The benefit over the InsertField SMT is that the payload is not
+ * modified leading to less memory used and less CPU time.
+ *
+ * @param <R> the record type
+ */
+public class InsertWallclockHeaders<R extends ConnectRecord<R>> extends InsertTimestampHeaders<R> {
+  private Supplier<Instant> instantSupplier = Instant::now;
+
+  protected InsertWallclockHeaders() {
+    super(InsertTimestampHeaders.CONFIG_DEF);
+  }
+
+  // Used solely for testing purposes
+  void setInstantSupplier(Supplier<Instant> instantSupplier) {
+    this.instantSupplier = instantSupplier;
+  }
+
+  @Override
+  protected Instant getInstant(R r) {
+    return instantSupplier.get();
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertRecordTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRecordTimestampHeadersTest.java
@@ -1,0 +1,108 @@
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link InsertWallclockHeaders}. */
+public class InsertRecordTimestampHeadersTest {
+
+  @Test
+  public void testAllHeaders() {
+    InsertRecordTimestampHeaders<SourceRecord> transformer = new InsertRecordTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    transformer.configure(configs);
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void testUsingKalkotaTimezone() {
+    InsertRecordTimestampHeaders<SourceRecord> transformer = new InsertRecordTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("timezone", "Asia/Kolkata");
+    transformer.configure(configs);
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("16", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("51", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void changeDatePattern() {
+    InsertRecordTimestampHeaders<SourceRecord> transformer = new InsertRecordTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("date.format", "yyyy-dd-MM");
+    transformer.configure(configs);
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-05-01", transformed.headers().lastWithName("wallclock.date").value());
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingRecordTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingRecordTimestampHeadersTest.java
@@ -1,0 +1,459 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link InsertRollingRecordTimestampHeaders}. */
+public class InsertRollingRecordTimestampHeadersTest {
+  @Test
+  public void testRollingWindowEvery15Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneSetToKalkota() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    // the first param to the Tuple5 is UTC. the third, fourth and figth arguments should be adapted
+    // to the Kalkota timezone
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Asia/Kolkata");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneIsParis() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Europe/Paris");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery5Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:04:59.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:00.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:01.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:09:59.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:00.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:01.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:24:59.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:00.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:01.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:34:59.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:00.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:01.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:39:59.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:00.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:01.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:49:59.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:00.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:01.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:54:59.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:00.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:01.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 5, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "minutes");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testFormattedWithRollingWindowOf1Hour() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:15:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:59:59.999Z"), 1, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowOf3Hours() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:19:59.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:59:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T06:00:00.000Z"), 3, "2020-01-01 06:00", "06", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery12Seconds() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:19:59.000Z"), 12, "2020-01-01 01:19:48", "19", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:00.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:01.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:02.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:11.999Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:12.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:13.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:23.999Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:24.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:25.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:35.999Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:36.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:37.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:47.999Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:48.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:49.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:59.999Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm:ss");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "seconds");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualSecond =
+              transformed.headers().lastWithName("second").value().toString();
+          assertEquals(actualSecond, scenario.fifth);
+        });
+  }
+
+  static class Tuple5<A, B, C, D, E> {
+    private final A first;
+    private final B second;
+    private final C third;
+    private final D fourth;
+    private final E fifth;
+
+    public Tuple5(A first, B second, C third, D fourth, E fifth) {
+      this.first = first;
+      this.second = second;
+      this.third = third;
+      this.fourth = fourth;
+      this.fifth = fifth;
+    }
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingWallclockHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingWallclockHeadersTest.java
@@ -1,0 +1,463 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link InsertRollingWallclock}. */
+public class InsertRollingWallclockHeadersTest {
+  @Test
+  public void testRollingWindowEvery15Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneSetToKalkota() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Asia/Kolkata");
+          final InsertRollingRecordTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingRecordTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneIsParis() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Europe/Paris");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery5Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:04:59.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:00.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:01.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:09:59.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:00.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:01.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:24:59.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:00.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:01.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:34:59.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:00.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:01.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:39:59.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:00.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:01.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:49:59.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:00.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:01.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:54:59.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:00.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:01.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 5, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "minutes");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testFormattedWithRollingWindowOf1Hour() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:15:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:59:59.999Z"), 1, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowOf3Hours() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:19:59.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:59:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T06:00:00.000Z"), 3, "2020-01-01 06:00", "06", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery12Seconds() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:19:59.000Z"), 12, "2020-01-01 01:19:48", "19", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:00.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:01.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:02.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:11.999Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:12.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:13.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:23.999Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:24.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:25.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:35.999Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:36.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:37.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:47.999Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:48.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:49.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:59.999Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm:ss");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "seconds");
+          final InsertRollingWallclockHeaders<SourceRecord> transformer =
+              new InsertRollingWallclockHeaders<>();
+          transformer.configure(configs);
+          transformer.setInstantSupplier(() -> Instant.parse(scenario.first));
+
+          final Headers headers = new ConnectHeaders();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.STRING_SCHEMA,
+                  "value",
+                  Instant.parse(scenario.first).toEpochMilli(),
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualSecond =
+              transformed.headers().lastWithName("second").value().toString();
+          assertEquals(actualSecond, scenario.fifth);
+        });
+  }
+
+  static class Tuple5<A, B, C, D, E> {
+    private final A first;
+    private final B second;
+    private final C third;
+    private final D fourth;
+    private final E fifth;
+
+    public Tuple5(A first, B second, C third, D fourth, E fifth) {
+      this.first = first;
+      this.second = second;
+      this.third = third;
+      this.fourth = fourth;
+      this.fifth = fifth;
+    }
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertWallclockHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertWallclockHeadersTest.java
@@ -1,0 +1,111 @@
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link io.lenses.connect.smt.header.InsertWallclockHeaders}. */
+public class InsertWallclockHeadersTest {
+
+  @Test
+  public void testAllHeaders() {
+    InsertWallclockHeaders<SourceRecord> transformer = new InsertWallclockHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    transformer.configure(configs);
+    transformer.setInstantSupplier(() -> Instant.parse("2020-01-05T11:21:04.000Z"));
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            System.currentTimeMillis(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void testUsingKalkotaTimezone() {
+    InsertWallclockHeaders<SourceRecord> transformer = new InsertWallclockHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("timezone", "Asia/Kolkata");
+    transformer.configure(configs);
+    transformer.setInstantSupplier(() -> Instant.parse("2020-01-05T11:21:04.000Z"));
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            System.currentTimeMillis(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("16", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("51", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void changeDatePattern() {
+    InsertWallclockHeaders<SourceRecord> transformer = new InsertWallclockHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("date.format", "yyyy-dd-MM");
+    transformer.configure(configs);
+    transformer.setInstantSupplier(() -> Instant.parse("2020-01-05T11:21:04.000Z"));
+
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.STRING_SCHEMA,
+            "value",
+            System.currentTimeMillis(),
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-05-01", transformed.headers().lastWithName("wallclock.date").value());
+  }
+}


### PR DESCRIPTION
When dealing with partitioned data, such as using formats like `yyyy/MM/dd/HH` or `yyyy-MM-dd`/`HH`, users often face complexity in configuration. This complexity arises from needing multiple Single Message Transforms (SMTs) for each partition component, leading to a cumbersome setup. Additional settings like timezone or rolling window further compound the configuration size.

This PR addresses this complexity by introducing four new SMTs to streamline configuration:

1. Wallclock headers
2. Wallclock headers with rolling window
3. Record timestamp headers
4. Record timestamp headers with rolling window

Each of these SMTs adds headers to the resulting record, including date, year, month, day, hour, minute, and second. Users can customize the format of each header, allowing for flexibility. For instance, to support Hive-like partition naming, users can set the `date.format` to `day=yyyy/MM/dd`.

Moreover, users can optionally prefix the headers. This enhancement aims to make these headers available directly in the S3/Azure/GCS KCQL setting, simplifying the configuration process. For example:

```
connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY date, year
```