### PR TITLE
Support record field timestamp

### DIFF
--- a/InsertFieldTimestampHeaders.md
+++ b/InsertFieldTimestampHeaders.md
@@ -1,0 +1,126 @@
+# Insert Wallclock
+
+## Description
+
+Got it, here's the revised text with just the paragraph:
+
+---
+
+This Kafka Connect Single Message Transform (SMT) facilitates the insertion of date and time components (year, month,
+day, hour, minute, second) as headers into Kafka messages using a timestamp field within the message payload. The
+timestamp field can be in various valid formats, including long integers, strings, or date objects. The timestamp field
+can originate from either the record Key or the record Value. When extracting from the record Key, prefix the field
+with `_key.`; otherwise, extract from the record Value by default or explicitly using the field without prefixing. For
+string-formatted fields, specify a `format.from.pattern` parameter to define the parsing pattern. Long integer fields
+are assumed to be Unix timestamps; the desired Unix precision can be specified using the `unix.precision` parameter.
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header._date, _header._hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header._year, _header._month, _header._day, _header._hour
+```
+
+## Configuration
+
+| Name                  | Description                                                                                                                                                                         | Type   | Default      |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|--------------|
+| `field`               | The field name. If the key is part of the record Key prefix with `_key` otherwise `_value`. If `_value` or `_key` is not used it defaults to the record Value to resolve the field. | String |              |
+| `format.from.pattern` | Optional date timeFormatter-compatible format for the timestamp. Used to parse the input if the input is a string.                                                                  | String |              |
+| `unix.precision`      | Optional "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, or nanoseconds. Used to parse the input if the input is a Long.                        | String | milliseconds |
+| `header.prefix.name`  | Optional header prefix.                                                                                                                                                             | String |              |
+| `date.format`         | Optional Java date time formatter.                                                                                                                                                  | String | yyyy-MM-dd   |
+| `year.format`         | Optional Java date time formatter for the year component.                                                                                                                           | String | yyyy         |
+| `month.format`        | Optional Java date time formatter for the month component.                                                                                                                          | String | MM           |
+| `day.format`          | Optional Java date time formatter for the day component.                                                                                                                            | String | dd           |
+| `hour.format`         | Optional Java date time formatter for the hour component.                                                                                                                           | String | HH           |
+| `minute.format`       | Optional Java date time formatter for the minute component.                                                                                                                         | String | mm           |
+| `second.format`       | Optional Java date time formatter for the second component.                                                                                                                         | String | ss           |
+| `timezone`            | Optional. Sets the timezone. It can be any valid Java timezone.                                                                                                                     | String | UTC          |
+| `locale`              | Optional. Sets the locale. It can be any valid Java locale.                                                                                                                         | String | en           |
+
+## Example
+
+To use the record Value field named `created_at` as the unix timestamp, use the following:
+
+```properties
+transforms=fieldTs
+field=_value.created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeaders
+```
+
+To use the record Key field named `created_at` as the unix timestamp, use the following:
+
+```properties
+transforms=fieldTs
+field=_key.created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeaders
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=fieldTs
+field=created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeaders
+transforms.fieldTs.header.prefix.name=wallclock_
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=fieldTs
+field=created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeader
+transforms.fieldTs.date.format=yyyy-MM-dd
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=fieldTs
+field=created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeader
+transforms.fieldTs.timezone=Asia/Kolkata
+```
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=fieldTs
+field=created_at
+transforms.fieldTs.type=io.lenses.connect.smt.header.InsertFieldTimestampHeader    
+transforms.fieldTs.date.format="date=yyyy-MM-dd"
+transforms.fieldTs.hour.format="hour=yyyy"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header.date, _header.year
+```

--- a/InsertRollingFieldTimestampHeaders.md
+++ b/InsertRollingFieldTimestampHeaders.md
@@ -1,0 +1,129 @@
+# Insert Wallclock
+
+## Description
+
+A Kafka Connect Single Message Transform (SMT) that inserts date, year, month,day, hour, minute and second headers using
+a timestamp field from the record payload and a rolling time window configuration. The timestamp field can be in various
+valid formats, including long integers, strings, or date objects. The timestamp field
+can originate from either the record Key or the record Value. When extracting from the record Key, prefix the field
+with `_key.`; otherwise, extract from the record Value by default or explicitly using the field without prefixing. For
+string-formatted fields, specify a `format.from.pattern` parameter to define the parsing pattern. Long integer fields
+are assumed to be Unix timestamps; the desired Unix precision can be specified using the `unix.precision` parameter.
+
+The headers inserted are of type STRING. By using this SMT, you can partition the data by `yyyy-MM-dd/HH`
+or `yyyy/MM/dd/HH`, for example, and only use one SMT.
+
+The list of headers inserted are:
+
+* date
+* year
+* month
+* day
+* hour
+* minute
+* second
+
+All headers can be prefixed with a custom prefix. For example, if the prefix is `wallclock_`, then the headers will be:
+
+* wallclock_date
+* wallclock_year
+* wallclock_month
+* wallclock_day
+* wallclock_hour
+* wallclock_minute
+* wallclock_second
+
+When used with the Lenses connectors for S3, GCS or Azure data lake, the headers can be used to partition the data.
+Considering the headers have been prefixed by `_`, here are a few KCQL examples:
+
+```
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header._date, _header._hour
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header._year, _header._month, _header._day, _header._hour
+```
+
+## Configuration
+
+| Name                  | Description                                                                                                                                                                         | Type   | Default      |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|--------------|
+| `field`               | The field name. If the key is part of the record Key prefix with `_key` otherwise `_value`. If `_value` or `_key` is not used it defaults to the record Value to resolve the field. | String |              |
+| `format.from.pattern` | Optional date timeFormatter-compatible format for the timestamp. Used to parse the input if the input is a string.                                                                  | String |              |
+| `unix.precision`      | Optional "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, or nanoseconds. Used to parse the input if the input is a Long.                        | String | milliseconds |
+| `header.prefix.name`  | Optional header prefix.                                                                                                                                                             | String |              |
+| `date.format`         | Optional Java date time formatter.                                                                                                                                                  | String | yyyy-MM-dd   |
+| `year.format`         | Optional Java date time formatter for the year component.                                                                                                                           | String | yyyy         |
+| `month.format`        | Optional Java date time formatter for the month component.                                                                                                                          | String | MM           |
+| `day.format`          | Optional Java date time formatter for the day component.                                                                                                                            | String | dd           |
+| `hour.format`         | Optional Java date time formatter for the hour component.                                                                                                                           | String | HH           |
+| `minute.format`       | Optional Java date time formatter for the minute component.                                                                                                                         | String | mm           |
+| `second.format`       | Optional Java date time formatter for the second component.                                                                                                                         | String | ss           |
+| `timezone`            | Optional. Sets the timezone. It can be any valid Java timezone.                                                                                                                     | String | UTC          |
+| `locale`              | Optional. Sets the locale. It can be any valid Java locale.                                                                                                                         | String | en           |
+| `rolling.window.type` | Sets the window type. It can be fixed or rolling.                                                                                                                                   | String | minutes      |  
+| `rolling.window.size` | Sets the window size. It can be any positive integer, and depending on the `window.type` it has an upper bound, 60 for seconds and minutes, and 24 for hours.                       | Int    | 15           | 
+
+## Example
+
+To store the epoch value, use the following configuration:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingFieldTimestampHeaders
+transforms.rollingWindow.field=created_at
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To prefix the headers with `wallclock_`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingFieldTimestampHeaders
+transforms.rollingWindow.field=created_at
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+```
+
+To change the date format, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingFieldTimestampHeaders
+transforms.rollingWindow.field=created_at
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+```
+
+To use the timezone `Asia/Kolkoata`, use the following:
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingFieldTimestampHeaders
+transforms.rollingWindow.field=created_at
+transforms.rollingWindow.header.prefix.name=wallclock_
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+```
+
+To facilitate S3, GCS, or Azure Data Lake partitioning using a Hive-like partition name format, such
+as `date=yyyy-MM-dd / hour=HH`, employ the following SMT configuration for a partition strategy.
+
+```properties
+transforms=rollingWindow
+transforms.rollingWindow.type=io.lenses.connect.smt.header.InsertRollingFieldTimestampHeaders
+transforms.rollingWindow.field=created_at
+transforms.rollingWindow.rolling.window.type=minutes
+transforms.rollingWindow.rolling.window.size=15
+transforms.rollingWindow.timezone=Asia/Kolkata
+transforms.rollingWindow.date.format="date=yyyy-MM-dd"
+transforms.rollingWindow.hour.format="hour=yyyy"
+```
+
+and in the KCQL setting utilise the headers as partitioning keys:
+
+```properties
+connect.s3.kcql=INSERT INTO $bucket:prefix SELECT * FROM kafka_topic PARTITIONBY _header.date, _header.year
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Furthermore, they support [Stream-Reactor](https://github.com/lensesio/stream-re
 * [InsertRollingRecordTimestampHeaders](./InsertRollingRecordTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the record timestamp and a rolling time window configuration.
 * [InsertRollingWallclockHeaders](./InsertRollingWallclockHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the system timestamp and a rolling time window configuration.
 * [InsertRecordTimestampHeaders](./InsertRecordTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the record timestamp.
+* [InsertFieldTimestampHeaders](./InsertFieldTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using a field in the payload, record Key or Value.
+* [InsertRollingFieldTimestampHeaders](./InsertRollingFieldTimestampHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using a field in the payload, record Key or Value and a rolling window boundary.
 * [InsertWallclockHeaders](./InsertWallclockHeaders.md) - Inserts date, year, month, day, hour, minute, and second headers using the system clock.
 * [TimestampConverter](./TimestampConverter.md) - Converts a timestamp field in the payload, record Key or Value to a different format, and optionally applies a rolling window boundary. An adapted version of the one packed in the Kafka Connect framework.
 * [InsertWallclockDateTimePart](./InsertWallclockDateTimePart.md) - Inserts the system clock year, month, day, minute, or seconds as a message header, with a value of type STRING.

--- a/src/main/java/io/lenses/connect/smt/header/FieldType.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldType.java
@@ -1,0 +1,7 @@
+package io.lenses.connect.smt.header;
+
+enum FieldType {
+  KEY,
+  VALUE,
+  TIMESTAMP
+}

--- a/src/main/java/io/lenses/connect/smt/header/FieldType.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldType.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 enum FieldType {

--- a/src/main/java/io/lenses/connect/smt/header/FieldTypeConstants.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldTypeConstants.java
@@ -1,0 +1,7 @@
+package io.lenses.connect.smt.header;
+
+public class FieldTypeConstants {
+  public static final String KEY_FIELD = "_key";
+  public static final String VALUE_FIELD = "_value";
+  public static final String TIMESTAMP_FIELD = "_timestamp";
+}

--- a/src/main/java/io/lenses/connect/smt/header/FieldTypeConstants.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldTypeConstants.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 public class FieldTypeConstants {

--- a/src/main/java/io/lenses/connect/smt/header/FieldTypeUtils.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldTypeUtils.java
@@ -1,0 +1,54 @@
+package io.lenses.connect.smt.header;
+
+import java.util.Arrays;
+import org.apache.kafka.common.config.ConfigException;
+
+class FieldTypeUtils {
+  public static FieldTypeAndFields extractFieldTypeAndFields(String from) {
+    FieldType fieldType;
+    String[] fields = from.split("\\.");
+    if (fields.length > 0) {
+      if (fields[0].equalsIgnoreCase(FieldTypeConstants.KEY_FIELD)) {
+        fieldType = FieldType.KEY;
+        // drop the first element
+        fields = Arrays.copyOfRange(fields, 1, fields.length);
+      } else if (fields[0].equalsIgnoreCase(FieldTypeConstants.TIMESTAMP_FIELD)) {
+        fieldType = FieldType.TIMESTAMP;
+        // if fields length is > 1, then it is an error since the timestamp is a primitive
+        if (fields.length > 1) {
+          throw new ConfigException(
+              "When using the record timestamp field, the field path should only be '_timestamp'.");
+        }
+        fields = new String[0];
+      } else {
+        fieldType = FieldType.VALUE;
+        if (fields[0].equalsIgnoreCase(FieldTypeConstants.VALUE_FIELD)) {
+          // drop the first element
+          fields = Arrays.copyOfRange(fields, 1, fields.length);
+        }
+      }
+    } else {
+      fieldType = FieldType.VALUE;
+    }
+
+    return new FieldTypeAndFields(fieldType, fields);
+  }
+
+  static class FieldTypeAndFields {
+    private final FieldType fieldType;
+    private final String[] fields;
+
+    public FieldTypeAndFields(FieldType fieldType, String[] fields) {
+      this.fieldType = fieldType;
+      this.fields = fields;
+    }
+
+    public FieldType getFieldType() {
+      return fieldType;
+    }
+
+    public String[] getFields() {
+      return fields;
+    }
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/FieldTypeUtils.java
+++ b/src/main/java/io/lenses/connect/smt/header/FieldTypeUtils.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import java.util.Arrays;

--- a/src/main/java/io/lenses/connect/smt/header/InsertFieldTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertFieldTimestampHeaders.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * A transformer which takes a record filed of type timestamp and inserts a header year, month, day,
+ * hour, minute, second and date.
+ *
+ * @param <R> the record type
+ */
+public class InsertFieldTimestampHeaders<R extends ConnectRecord<R>>
+    extends InsertTimestampHeaders<R> {
+
+  public static ConfigDef CONFIG_DEF =
+      RecordFieldTimestamp.extendConfigDef(InsertTimestampHeaders.CONFIG_DEF);
+  private RecordFieldTimestamp<R> fieldTimestamp;
+
+  public InsertFieldTimestampHeaders() {
+    super(InsertRecordTimestampHeaders.CONFIG_DEF);
+  }
+
+  @Override
+  protected Instant getInstant(R r) {
+    return fieldTimestamp.getInstant(r);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  protected void configureInternal(SimpleConfig config) {
+
+    super.configureInternal(config);
+    fieldTimestamp = RecordFieldTimestamp.create(config, timeZone, locale);
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeaders.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import java.time.Instant;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * A transformer which takes a record filed of type timestamp and inserts a header year, month, day,
+ * hour, minute, second and date.
+ *
+ * @param <R> the record type
+ */
+public class InsertRollingFieldTimestampHeaders<R extends ConnectRecord<R>>
+    extends InsertRollingTimestampHeaders<R> {
+
+  private RecordFieldTimestamp<R> fieldTimestamp;
+
+  public static ConfigDef CONFIG_DEF =
+      RecordFieldTimestamp.extendConfigDef(InsertRollingTimestampHeaders.CONFIG_DEF);
+
+  public InsertRollingFieldTimestampHeaders() {
+    super();
+  }
+
+  @Override
+  protected Instant getInstantInternal(R r) {
+    return fieldTimestamp.getInstant(r);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  protected void configureInternal(SimpleConfig config) {
+    super.configureInternal(config);
+    fieldTimestamp = RecordFieldTimestamp.create(config, timeZone, locale);
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
+++ b/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
@@ -1,0 +1,186 @@
+package io.lenses.connect.smt.header;
+
+import static io.lenses.connect.smt.header.FieldTypeConstants.KEY_FIELD;
+import static io.lenses.connect.smt.header.FieldTypeConstants.VALUE_FIELD;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_MICROS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_MILLIS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_NANOS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_SECONDS;
+import static io.lenses.connect.smt.header.Utils.convertToTimestamp;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+class RecordFieldTimestamp<R extends ConnectRecord<R>> {
+  private static final String FIELD_CONFIG = "field";
+  private static final String FORMAT_FROM_CONFIG = "format.from.pattern";
+
+  public static final String UNIX_PRECISION_CONFIG = "unix.precision";
+  private static final String UNIX_PRECISION_DEFAULT = "milliseconds";
+  private final FieldTypeUtils.FieldTypeAndFields fieldTypeAndFields;
+  private final Optional<DateTimeFormatter> fromPattern;
+  private final String unixPrecision;
+  private final ZoneId timeZone;
+
+  private RecordFieldTimestamp(
+      FieldTypeUtils.FieldTypeAndFields fieldTypeAndFields,
+      Optional<DateTimeFormatter> fromPattern,
+      String unixPrecision,
+      ZoneId timeZone) {
+
+    this.fieldTypeAndFields = fieldTypeAndFields;
+    this.fromPattern = fromPattern;
+    this.unixPrecision = unixPrecision;
+    this.timeZone = timeZone;
+  }
+
+  public FieldTypeUtils.FieldTypeAndFields getFieldTypeAndFields() {
+    return fieldTypeAndFields;
+  }
+
+  public Optional<DateTimeFormatter> getFromPattern() {
+    return fromPattern;
+  }
+
+  public String getUnixPrecision() {
+    return unixPrecision;
+  }
+
+  /**
+   * The check for null happens in InsertTimestampHeaders
+   *
+   * @param r the record
+   * @return the instant
+   */
+  public Instant getInstant(R r) {
+    FieldType fieldType = fieldTypeAndFields.getFieldType();
+    if (fieldType == FieldType.TIMESTAMP) {
+      return r.timestamp() == null ? Instant.now() : Instant.ofEpochMilli(r.timestamp());
+    } else {
+
+      final Object value = operatingValue(r);
+      if (value == null) {
+        return null;
+      }
+      if (fieldTypeAndFields.getFields().length == 0) {
+        return convertToTimestamp(value, unixPrecision, fromPattern, timeZone);
+      }
+      final Schema schema = operatingSchema(r);
+      Object extractedValue;
+      if (schema == null) {
+        // there's schemaless data; the input expected is a Map
+        extractedValue =
+            Utils.extractValue(
+                requireMap(
+                    value,
+                    "Extracting field value for:"
+                        + Arrays.toString(fieldTypeAndFields.getFields())),
+                fieldTypeAndFields.getFields());
+      } else if (value instanceof Struct) {
+        extractedValue = Utils.extractValue((Struct) value, fieldTypeAndFields.getFields());
+      } else {
+
+        throw new DataException(
+            "The SMT is configured to extract the data from: "
+                + Arrays.toString(fieldTypeAndFields.getFields())
+                + " thus it requires a Struct value. Found: "
+                + value.getClass().getName()
+                + " instead.");
+      }
+
+      return convertToTimestamp(extractedValue, unixPrecision, fromPattern, timeZone);
+    }
+  }
+
+  private Schema operatingSchema(R record) {
+    switch (fieldTypeAndFields.getFieldType()) {
+      case KEY:
+        return record.keySchema();
+      case TIMESTAMP:
+        return Timestamp.SCHEMA;
+      default:
+        return record.valueSchema();
+    }
+  }
+
+  private Object operatingValue(R record) {
+    if (fieldTypeAndFields.getFieldType() == FieldType.TIMESTAMP) {
+      return record.timestamp();
+    }
+    if (fieldTypeAndFields.getFieldType() == FieldType.KEY) {
+      return record.key();
+    }
+    return record.value();
+  }
+
+  public static <R extends ConnectRecord<R>> RecordFieldTimestamp<R> create(
+      SimpleConfig config, ZoneId zoneId, Locale locale) {
+    String fieldConfig = config.getString(FIELD_CONFIG);
+    if (fieldConfig == null || fieldConfig.isEmpty()) {
+      fieldConfig = FieldTypeConstants.VALUE_FIELD;
+    }
+
+    final FieldTypeUtils.FieldTypeAndFields fieldTypeAndFields =
+        FieldTypeUtils.extractFieldTypeAndFields(fieldConfig);
+
+    final String unixPrecision =
+        Optional.ofNullable(config.getString(UNIX_PRECISION_CONFIG)).orElse(UNIX_PRECISION_DEFAULT);
+
+    final Optional<DateTimeFormatter> fromPattern =
+        Optional.ofNullable(config.getString(FORMAT_FROM_CONFIG))
+            .map(
+                pattern ->
+                    InsertTimestampHeaders.createDateTimeFormatter(
+                        pattern, FORMAT_FROM_CONFIG, locale));
+
+    return new RecordFieldTimestamp<>(fieldTypeAndFields, fromPattern, unixPrecision, zoneId);
+  }
+
+  public static ConfigDef extendConfigDef(ConfigDef from) {
+    return from.define(
+            FIELD_CONFIG,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.HIGH,
+            "The field path containing the timestamp, or empty if the entire value"
+                + " is a timestamp. Prefix the path with the literal string '"
+                + KEY_FIELD
+                + "' or '"
+                + VALUE_FIELD
+                + "' to specify the record key or value."
+                + "If no prefix is specified, the default is '"
+                + VALUE_FIELD
+                + "'.")
+        .define(
+            FORMAT_FROM_CONFIG,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigDef.Importance.MEDIUM,
+            "A DateTimeFormatter-compatible format for the timestamp. Used to parse the"
+                + " input if the input is a string.")
+        .define(
+            UNIX_PRECISION_CONFIG,
+            ConfigDef.Type.STRING,
+            UNIX_PRECISION_DEFAULT,
+            ConfigDef.ValidString.in(
+                UNIX_PRECISION_NANOS, UNIX_PRECISION_MICROS,
+                UNIX_PRECISION_MILLIS, UNIX_PRECISION_SECONDS),
+            ConfigDef.Importance.LOW,
+            "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, "
+                + "or nanoseconds. Used to generate the output when type=unix or used to parse "
+                + "the input if the input is a Long. This SMT will cause precision loss during "
+                + "conversions from, and to, values with sub-millisecond components.");
+  }
+}

--- a/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
+++ b/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import static io.lenses.connect.smt.header.FieldTypeConstants.KEY_FIELD;
@@ -179,8 +189,7 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
                 UNIX_PRECISION_MILLIS, UNIX_PRECISION_SECONDS),
             ConfigDef.Importance.LOW,
             "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, "
-                + "or nanoseconds. Used to generate the output when type=unix or used to parse "
-                + "the input if the input is a Long. This SMT will cause precision loss during "
+                + "or nanoseconds. Used to parse the input if the input is a Long. This SMT will cause precision loss during "
                 + "conversions from, and to, values with sub-millisecond components.");
   }
 }

--- a/src/main/java/io/lenses/connect/smt/header/UnixPrecisionConstants.java
+++ b/src/main/java/io/lenses/connect/smt/header/UnixPrecisionConstants.java
@@ -1,0 +1,8 @@
+package io.lenses.connect.smt.header;
+
+public class UnixPrecisionConstants {
+  public static final String UNIX_PRECISION_MILLIS = "milliseconds";
+  public static final String UNIX_PRECISION_MICROS = "microseconds";
+  public static final String UNIX_PRECISION_NANOS = "nanoseconds";
+  public static final String UNIX_PRECISION_SECONDS = "seconds";
+}

--- a/src/main/java/io/lenses/connect/smt/header/UnixPrecisionConstants.java
+++ b/src/main/java/io/lenses/connect/smt/header/UnixPrecisionConstants.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 public class UnixPrecisionConstants {

--- a/src/main/java/io/lenses/connect/smt/header/Utils.java
+++ b/src/main/java/io/lenses/connect/smt/header/Utils.java
@@ -10,11 +10,131 @@
  */
 package io.lenses.connect.smt.header;
 
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_MICROS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_MILLIS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_NANOS;
+import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION_SECONDS;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 
 class Utils {
+
+  static Instant convertToTimestamp(
+      Object value, String unixPrecision, Optional<DateTimeFormatter> fromPattern, ZoneId zoneId) {
+    if (value == null) {
+      return Instant.now();
+    }
+    if (value instanceof Instant) {
+      return (Instant) value;
+    }
+    if (value instanceof Long) {
+      switch (unixPrecision) {
+        case UNIX_PRECISION_SECONDS:
+          return new Date(TimeUnit.SECONDS.toMillis((Long) value)).toInstant();
+        case UNIX_PRECISION_MICROS:
+          return new Date(TimeUnit.MICROSECONDS.toMillis((Long) value)).toInstant();
+        case UNIX_PRECISION_NANOS:
+          return new Date(TimeUnit.NANOSECONDS.toMillis((Long) value)).toInstant();
+        case UNIX_PRECISION_MILLIS:
+        default:
+          return new Date((Long) value).toInstant();
+      }
+    }
+    if (value instanceof String) {
+      return fromPattern
+          .map(
+              pattern -> {
+                try {
+                  final LocalDateTime localDateTime = LocalDateTime.parse((String) value, pattern);
+                  return localDateTime.atZone(zoneId).toInstant();
+                } catch (Exception e) {
+                  throw new DataException(
+                      "Could not parse the string timestamp: "
+                          + value
+                          + " with pattern: "
+                          + pattern,
+                      e);
+                }
+              })
+          .orElseGet(
+              () -> {
+                try {
+                  return Instant.ofEpochMilli(Long.parseLong((String) value));
+                } catch (NumberFormatException e) {
+                  throw new DataException("Expected a long, but found " + value);
+                }
+              });
+    }
+    if (value instanceof Date) {
+      return ((Date) value).toInstant();
+    }
+    throw new DataException(
+        "Expected an epoch, date or string date, but found " + value.getClass());
+  }
+
+  /**
+   * Extracts the value for the given field path from a Map
+   *
+   * @param from the map to extract the value from
+   * @param fields the field path
+   * @return the value for the given field path
+   */
+  static Object extractValue(Map<String, Object> from, String[] fields) {
+    Map<String, Object> updatedValue =
+        requireMap(from, "Extracting value from: " + Arrays.toString(fields));
+    for (int i = 0; i < fields.length - 1; i++) {
+      updatedValue =
+          requireMap(
+              updatedValue.get(fields[i]), "Extracting value from: " + Arrays.toString(fields));
+      if (updatedValue == null) {
+        return null;
+      }
+    }
+    // updatedValue is now the map containing the field to be updated
+    // config.fields[config.fields.length-1] is the name of the field to be updated
+    return updatedValue.get(fields[fields.length - 1]);
+  }
+
+  /**
+   * Extracts the value of a given field from the given Struct
+   *
+   * @param from Struct to extract the value from
+   * @param fields the path to the field to extract
+   * @return the value of the field, or null if the field does not exist
+   */
+  static Object extractValue(Struct from, String[] fields) {
+    if (from == null) {
+      return null;
+    }
+    Struct updatedValue = from;
+
+    for (int i = 0; i < fields.length - 1; i++) {
+      updatedValue = updatedValue.getStruct(fields[i]);
+      if (updatedValue == null) {
+        return null;
+      }
+    }
+    // updatedValue is now the struct containing the field to be updated
+    // config.fields[config.fields.length-1] is the name of the field to be updated
+    Field field = updatedValue.schema().field(fields[fields.length - 1]);
+    if (field == null) {
+      return null;
+    }
+    return updatedValue.get(fields[fields.length - 1]);
+  }
 
   static DateTimeFormatter getDateFormat(String formatPattern, ZoneId zoneId) {
     if (formatPattern == null) {

--- a/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import static java.time.ZoneOffset.UTC;

--- a/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
@@ -1,0 +1,99 @@
+package io.lenses.connect.smt.header;
+
+import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.Test;
+
+public class ConvertToTimestampTest {
+
+  @Test
+  public void convertToTimestampReturnsCurrentTimeWhenValueIsNull() {
+    Instant result =
+        Utils.convertToTimestamp(null, "seconds", Optional.empty(), ZoneId.systemDefault());
+    assertNotNull(result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsSameInstantWhenValueIsInstant() {
+    Instant instant = Instant.now();
+    Instant result =
+        Utils.convertToTimestamp(instant, "seconds", Optional.empty(), ZoneId.systemDefault());
+    assertEquals(instant, result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsLong() {
+    Long value = 1633097000L; // corresponds to 2021-10-01T11:30:00Z
+    Instant result =
+        Utils.convertToTimestamp(value, "seconds", Optional.empty(), ZoneId.systemDefault());
+    assertEquals(Instant.ofEpochSecond(value), result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsString() {
+    String value = "2021-10-01T11:30:00Z";
+    Instant result =
+        Utils.convertToTimestamp(
+            value,
+            "seconds",
+            Optional.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZZZZZ").withZone(UTC)),
+            UTC);
+    assertEquals(Instant.parse(value), result);
+  }
+
+  @Test
+  public void convertToTimestampThrowsDataExceptionWhenValueIsInvalidString() {
+    String value = "invalid";
+    assertThrows(
+        DataException.class,
+        () ->
+            Utils.convertToTimestamp(
+                value,
+                "seconds",
+                Optional.of(
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZZZZZ").withZone(UTC)),
+                UTC));
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsEpochAndPrecisionIsMicros() {
+    Long value = 1633097000000000L; // corresponds to 2021-10-01T11:30:00Z
+    Instant result =
+        Utils.convertToTimestamp(value, "microseconds", Optional.empty(), ZoneId.systemDefault());
+    assertEquals(Instant.ofEpochSecond(1633097000L, 0), result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsEpochAndPrecisionIsNanos() {
+    Long value = 1633097000000000L; // corresponds to 2021-10-01T11:30:00Z
+    Instant result =
+        Utils.convertToTimestamp(value, "nanoseconds", Optional.empty(), ZoneId.systemDefault());
+    // Convert nanoseconds to seconds and add to epoch second
+    Instant expected = Instant.ofEpochSecond(value / 1_000_000_000L);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsEpochAndPrecisionIsMillis() {
+    Long value = 1633097000000L; // corresponds to 2021-10-01T11:30:00Z
+    Instant result =
+        Utils.convertToTimestamp(value, "milliseconds", Optional.empty(), ZoneId.systemDefault());
+    assertEquals(Instant.ofEpochSecond(1633097000L, 0), result);
+  }
+
+  @Test
+  public void convertToTimestampReturnsCorrectInstantWhenValueIsEpochAndPrecisionIsSeconds() {
+    Long value = 1633097000L; // corresponds to 2021-10-01T11:30:00Z
+    Instant result =
+        Utils.convertToTimestamp(value, "seconds", Optional.empty(), ZoneId.systemDefault());
+    assertEquals(Instant.ofEpochSecond(1633097000L, 0), result);
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertFieldTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertFieldTimestampHeadersTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link InsertFieldTimestampHeadersTest}. */
+public class InsertFieldTimestampHeadersTest {
+
+  @Test
+  public void testAllHeaders() {
+    InsertFieldTimestampHeaders<SinkRecord> transformer = new InsertFieldTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("field", "_value");
+    transformer.configure(configs);
+
+    Long expected = Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli();
+    final Headers headers = new ConnectHeaders();
+    final SinkRecord record =
+        new SinkRecord(
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            null,
+            Schema.INT64_SCHEMA,
+            expected,
+            0,
+            expected,
+            TimestampType.LOG_APPEND_TIME,
+            headers);
+    final SinkRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void testUsingKalkotaTimezone() {
+    InsertFieldTimestampHeaders<SourceRecord> transformer = new InsertFieldTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("timezone", "Asia/Kolkata");
+    configs.put("field", "_value");
+    transformer.configure(configs);
+
+    long expected = Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli();
+    final Headers headers = new ConnectHeaders();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.INT64_SCHEMA,
+            expected,
+            expected,
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("16", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("51", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-01-05", transformed.headers().lastWithName("wallclock.date").value());
+  }
+
+  @Test
+  public void changeDatePattern() {
+    InsertFieldTimestampHeaders<SourceRecord> transformer = new InsertFieldTimestampHeaders<>();
+    Map<String, String> configs = new HashMap<>();
+    configs.put("header.prefix.name", "wallclock.");
+    configs.put("date.format", "yyyy-dd-MM");
+    configs.put("field", "_value");
+    transformer.configure(configs);
+
+    final Headers headers = new ConnectHeaders();
+    long expected = Instant.parse("2020-01-05T11:21:04.000Z").toEpochMilli();
+    final SourceRecord record =
+        new SourceRecord(
+            null,
+            null,
+            "topic",
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            Schema.INT64_SCHEMA,
+            expected,
+            expected,
+            headers);
+    final SourceRecord transformed = transformer.apply(record);
+    assertEquals("2020", transformed.headers().lastWithName("wallclock.year").value());
+    assertEquals("01", transformed.headers().lastWithName("wallclock.month").value());
+    assertEquals("05", transformed.headers().lastWithName("wallclock.day").value());
+    assertEquals("11", transformed.headers().lastWithName("wallclock.hour").value());
+    assertEquals("21", transformed.headers().lastWithName("wallclock.minute").value());
+    assertEquals("04", transformed.headers().lastWithName("wallclock.second").value());
+    assertEquals("2020-05-01", transformed.headers().lastWithName("wallclock.date").value());
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
@@ -1,0 +1,420 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link InsertRollingRecordTimestampHeaders}. */
+public class InsertRollingFieldTimestampHeadersTest {
+  @Test
+  public void testRollingWindowEvery15Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 01:45", "01", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("field", "_value");
+
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneSetToKalkota() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    // the first param to the Tuple5 is UTC. the third, fourth and figth arguments should be adapted
+    // to the Kalkota timezone
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 06:30", "06", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 06:45", "06", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 07:00", "07", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 07:15", "07", "15"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Asia/Kolkata");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery15MinutesAndTimezoneIsParis() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 15, "2020-01-01 02:15", "02", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 02:30", "02", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 15, "2020-01-01 02:45", "02", "45"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("window.size", scenario.second.toString());
+          configs.put("window.type", "minutes");
+          configs.put("timezone", "Europe/Paris");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null,
+                  null,
+                  "topic",
+                  0,
+                  Schema.STRING_SCHEMA,
+                  "key",
+                  Schema.INT64_SCHEMA,
+                  expected,
+                  0L,
+                  headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+          final String actualMinute =
+              transformed.headers().lastWithName("_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery5Minutes() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:00:01.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:04:59.000Z"), 5, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:00.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:05:01.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:09:59.000Z"), 5, "2020-01-01 01:05", "01", "05"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:00.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:10:01.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:14:59.000Z"), 5, "2020-01-01 01:10", "01", "10"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:00.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:15:01.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.000Z"), 5, "2020-01-01 01:15", "01", "15"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:24:59.000Z"), 5, "2020-01-01 01:20", "01", "20"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:00.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:25:01.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:29:59.000Z"), 5, "2020-01-01 01:25", "01", "25"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:00.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:30:01.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:34:59.000Z"), 5, "2020-01-01 01:30", "01", "30"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:00.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:35:01.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:39:59.000Z"), 5, "2020-01-01 01:35", "01", "35"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:00.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:40:01.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:44:59.000Z"), 5, "2020-01-01 01:40", "01", "40"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:00.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:45:01.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:49:59.000Z"), 5, "2020-01-01 01:45", "01", "45"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:00.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:50:01.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:54:59.000Z"), 5, "2020-01-01 01:50", "01", "50"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:00.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:55:01.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 5, "2020-01-01 01:55", "01", "55"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 5, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "minutes");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
+
+  @Test
+  public void testFormattedWithRollingWindowOf1Hour() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:59:59.000Z"), 1, "2020-01-01 01:00", "01", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:00:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:15:00.000Z"), 1, "2020-01-01 02:00", "02", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:59:59.999Z"), 1, "2020-01-01 02:00", "02", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("header.prefix.name", "wallclock_");
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowOf3Hours() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T01:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:19:59.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T02:20:01.000Z"), 3, "2020-01-01 00:00", "00", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T03:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T04:20:01.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:19:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:20:00.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T05:59:59.000Z"), 3, "2020-01-01 03:00", "03", "00"));
+    scenarios.add(new Tuple5<>(("2020-01-01T06:00:00.000Z"), 3, "2020-01-01 06:00", "06", "00"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "hours");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualHour = transformed.headers().lastWithName("hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
+        });
+  }
+
+  @Test
+  public void testRollingWindowEvery12Seconds() {
+    ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:19:59.000Z"), 12, "2020-01-01 01:19:48", "19", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:00.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:01.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:02.000Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:11.999Z"), 12, "2020-01-01 01:20:00", "20", "00"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:12.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:13.000Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:23.999Z"), 12, "2020-01-01 01:20:12", "20", "12"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:24.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:25.000Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:35.999Z"), 12, "2020-01-01 01:20:24", "20", "24"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:36.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:37.000Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:47.999Z"), 12, "2020-01-01 01:20:36", "20", "36"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:48.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:49.000Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+    scenarios.add(
+        new Tuple5<>(("2020-01-01T01:20:59.999Z"), 12, "2020-01-01 01:20:48", "20", "48"));
+
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs = new HashMap<>();
+          configs.put("date.format", "yyyy-MM-dd HH:mm:ss");
+          configs.put("rolling.window.size", scenario.second.toString());
+          configs.put("rolling.window.type", "seconds");
+          configs.put("field", "_value");
+          final InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>();
+          transformer.configure(configs);
+
+          final Headers headers = new ConnectHeaders();
+          long expected = Instant.parse(scenario.first).toEpochMilli();
+          final SourceRecord record =
+              new SourceRecord(
+                  null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, expected, 0L, headers);
+          final SourceRecord transformed = transformer.apply(record);
+          final String actualDate = transformed.headers().lastWithName("date").value().toString();
+          assertEquals(actualDate, scenario.third);
+
+          final String actualSecond =
+              transformed.headers().lastWithName("second").value().toString();
+          assertEquals(actualSecond, scenario.fifth);
+        });
+  }
+
+  static class Tuple5<A, B, C, D, E> {
+    private final A first;
+    private final B second;
+    private final C third;
+    private final D fourth;
+    private final E fifth;
+
+    public Tuple5(A first, B second, C third, D fourth, E fifth) {
+      this.first = first;
+      this.second = second;
+      this.third = third;
+      this.fourth = fourth;
+      this.fifth = fifth;
+    }
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/RecordFieldTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/RecordFieldTimestampTest.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import static java.time.ZoneOffset.UTC;

--- a/src/test/java/io/lenses/connect/smt/header/RecordFieldTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/RecordFieldTimestampTest.java
@@ -1,0 +1,384 @@
+package io.lenses.connect.smt.header;
+
+import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RecordFieldTimestamp} unix.precision configuration tests are not required since
+ * Connect covers that
+ */
+class RecordFieldTimestampTest {
+
+  @Test
+  void nullRecordReturnsNullInstant() {
+    // generate the test creating an instance of RecordFieldTimestamp
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "value");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    Instant actual =
+        recordFieldTimestamp.getInstant(new SinkRecord("topic", 0, null, null, null, null, 0));
+    assert actual == null;
+  }
+
+  @Test
+  void fieldKeySetsTheFieldTypeToKeyTest() {
+    // generate the test creating an instance of RecordFieldTimestamp
+    String[] fields = new String[] {"_key", "_key.a", "_key.a.b"};
+    Arrays.stream(fields)
+        .forEach(
+            field -> {
+              Map<String, Object> props = new HashMap<>();
+              props.put("field", field);
+              props.put("format.from.pattern", "yyyy-MM-dd");
+              props.put("unix.precision", "milliseconds");
+
+              SimpleConfig config =
+                  new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+              RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+                  RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+              assertEquals(
+                  recordFieldTimestamp.getFieldTypeAndFields().getFieldType(), FieldType.KEY);
+            });
+  }
+
+  @Test
+  void unixPrecisionDefaultsWhenNotSet() {
+    // generate the test creating an instance of RecordFieldTimestamp
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    assertEquals(recordFieldTimestamp.getUnixPrecision(), "milliseconds");
+  }
+
+  @Test
+  void fieldKeySetsTheFieldTypeToValueTest() {
+    String[] fields = new String[] {"_value", "a", "a.b"};
+    Arrays.stream(fields)
+        .forEach(
+            field -> {
+              Map<String, Object> props = new HashMap<>();
+              props.put("field", field);
+              props.put("format.from.pattern", "yyyy-MM-dd");
+              props.put("unix.precision", "milliseconds");
+
+              SimpleConfig config =
+                  new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+              RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+                  RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+              assertEquals(
+                  recordFieldTimestamp.getFieldTypeAndFields().getFieldType(), FieldType.VALUE);
+            });
+  }
+
+  @Test
+  void fieldTimestampSetTheFieldTypeToTimestamp() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_timestamp");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    assertEquals(recordFieldTimestamp.getFieldTypeAndFields().getFieldType(), FieldType.TIMESTAMP);
+  }
+
+  @Test
+  void extendConfigDef() {
+    ConfigDef configDef = RecordFieldTimestamp.extendConfigDef(new ConfigDef());
+    assert configDef.configKeys().size() == 3;
+    assert configDef.configKeys().containsKey("field");
+    assert configDef.configKeys().containsKey("format.from.pattern");
+    assert configDef.configKeys().containsKey("unix.precision");
+  }
+
+  @Test
+  void whenFieldIsSetToTimestampTheRecordTimestampIsReturned() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_timestamp");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedTs = 123456789L;
+    Instant actual =
+        recordFieldTimestamp.getInstant(
+            new SinkRecord(
+                "topic", 0, null, null, null, null, 0, expectedTs, TimestampType.LOG_APPEND_TIME));
+    assertEquals(actual.toEpochMilli(), expectedTs);
+  }
+
+  @Test
+  void whenFieldIsSetToKeyItReturnsTheRecordKeyValueTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedKey = 123456789L;
+
+    SinkRecord[] records =
+        new SinkRecord[] {
+          new SinkRecord("topic", 0, null, expectedKey, null, null, 0),
+          new SinkRecord(
+              "topic",
+              0,
+              null,
+              expectedKey,
+              Schema.INT64_SCHEMA,
+              null,
+              0,
+              0L,
+              TimestampType.LOG_APPEND_TIME)
+        };
+    Arrays.stream(records)
+        .forEach(
+            record -> {
+              Instant actual = recordFieldTimestamp.getInstant(record);
+              assertEquals(actual.toEpochMilli(), expectedKey);
+            });
+  }
+
+  @Test
+  void whenFieldIsSetToValueItReturnsTheRecordValueTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_value");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 123456789L;
+
+    SinkRecord[] records =
+        new SinkRecord[] {
+          new SinkRecord("topic", 0, null, null, null, expectedValue, 0),
+          new SinkRecord(
+              "topic",
+              0,
+              null,
+              null,
+              Schema.INT64_SCHEMA,
+              expectedValue,
+              0,
+              0L,
+              TimestampType.LOG_APPEND_TIME)
+        };
+    Arrays.stream(records)
+        .forEach(
+            record -> {
+              Instant actual = recordFieldTimestamp.getInstant(record);
+              assertEquals(actual.toEpochMilli(), expectedValue);
+            });
+  }
+
+  @Test
+  void returnsTheKeyStructFieldWhenTheValueIsaLongTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key.a");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 123456789L;
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("a", Schema.INT64_SCHEMA)
+            .field("b", Schema.STRING_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema).put("a", expectedValue).put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, schema, struct, null, expectedValue, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  @Test
+  void returnsTheValueStructFieldWhenTheValueIsALongTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "a");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 123456789L;
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("a", Schema.INT64_SCHEMA)
+            .field("b", Schema.STRING_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema).put("a", expectedValue).put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, null, null, schema, struct, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  @Test
+  void returnsAKeyFieldWhenTheFieldValueIsAStringDateTimeRepresentationTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key.a");
+    props.put("format.from.pattern", "yyyy-MM-dd HH:mm:ss");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 1704067260000L;
+    String dateTimeValue = "2024-01-01 00:01:00";
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("a", Schema.STRING_SCHEMA)
+            .field("b", Schema.STRING_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema).put("a", dateTimeValue).put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, schema, struct, null, expectedValue, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  // create the tests where instead of struct we have a Map and schema is null
+
+  @Test
+  void returnsTheKeyMapFieldWhenTheValueIsaLongTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key.a");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 123456789L;
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", expectedValue);
+    map.put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, null, map, null, expectedValue, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  @Test
+  void returnsTheValueMapFieldWhenTheValueIsALongTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "a");
+    props.put("format.from.pattern", "yyyy-MM-dd");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 123456789L;
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", expectedValue);
+    map.put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, null, null, null, map, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  @Test
+  void returnsTheValueMapFieldWhenTheValueIsADateTimeStringTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "a");
+    props.put("format.from.pattern", "yyyy-MM-dd HH:mm:ss");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 1704067260000L;
+    String dateTimeValue = "2024-01-01 00:01:00";
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", dateTimeValue);
+    map.put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, null, null, null, map, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+
+  @Test
+  void returnsTheKeyMapFieldWhichContainsTheDateTimeStringTest() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("field", "_key.a");
+    props.put("format.from.pattern", "yyyy-MM-dd HH:mm:ss");
+    props.put("unix.precision", "milliseconds");
+
+    SimpleConfig config =
+        new SimpleConfig(RecordFieldTimestamp.extendConfigDef(new ConfigDef()), props);
+    RecordFieldTimestamp<SinkRecord> recordFieldTimestamp =
+        RecordFieldTimestamp.create(config, UTC, Locale.getDefault());
+    long expectedValue = 1704067260000L;
+    String dateTimeValue = "2024-01-01 00:01:00";
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", dateTimeValue);
+    map.put("b", "value");
+
+    SinkRecord input = new SinkRecord("topic", 0, null, map, null, expectedValue, 0);
+
+    Instant actual = recordFieldTimestamp.getInstant(input);
+    assertEquals(actual.toEpochMilli(), expectedValue);
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/UtilsExtractValueTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsExtractValueTest.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/lenses/connect/smt/header/UtilsExtractValueTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsExtractValueTest.java
@@ -1,0 +1,95 @@
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+public class UtilsExtractValueTest {
+
+  @Test
+  public void extractValueReturnsCorrectValueFromMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("key", "value");
+    Object result = Utils.extractValue(map, new String[] {"key"});
+    assertEquals("value", result);
+  }
+
+  @Test
+  public void extractValueReturnsNullWhenFieldDoesNotExistInMap() {
+    Map<String, Object> map = new HashMap<>();
+    Object result = Utils.extractValue(map, new String[] {"nonexistent"});
+    assertNull(result);
+  }
+
+  @Test
+  public void extractValueReturnsCorrectValueFromNestedMap() {
+    Map<String, Object> nestedMap = new HashMap<>();
+    nestedMap.put("key", "value");
+    Map<String, Object> map = new HashMap<>();
+    map.put("nested", nestedMap);
+    Object result = Utils.extractValue(map, new String[] {"nested", "key"});
+    assertEquals("value", result);
+  }
+
+  @Test
+  public void extractValueReturnsNullWhenFieldDoesNotExistInNestedMap() {
+    Map<String, Object> nestedMap = new HashMap<>();
+    nestedMap.put("key", "value");
+    Map<String, Object> map = new HashMap<>();
+    map.put("nested", nestedMap);
+    Object result = Utils.extractValue(map, new String[] {"nested", "nonexistent"});
+    assertNull(result);
+  }
+
+  @Test
+  public void extractValueFromAKafkaConnectStruct() {
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("field1", Schema.STRING_SCHEMA)
+            .field("field2", Schema.INT32_SCHEMA)
+            .build();
+
+    Struct struct = new Struct(schema).put("field1", "value1").put("field2", 42);
+
+    Object result = Utils.extractValue(struct, new String[] {"field1"});
+    assertEquals("value1", result);
+  }
+
+  @Test
+  public void extractValueReturnsNullWhenFieldDoesNotExistInStruct() {
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("field1", Schema.STRING_SCHEMA)
+            .field("field2", Schema.INT32_SCHEMA)
+            .build();
+
+    Struct struct = new Struct(schema).put("field1", "value1").put("field2", 42);
+
+    Object result = Utils.extractValue(struct, new String[] {"nonexistent"});
+    assertNull(result);
+  }
+
+  @Test
+  public void extractValueReturnsCorrectValueFromNestedStruct() {
+    Schema nestedSchema =
+        SchemaBuilder.struct()
+            .field("field1", Schema.STRING_SCHEMA)
+            .field("field2", Schema.INT32_SCHEMA)
+            .build();
+
+    Schema schema = SchemaBuilder.struct().field("nested", nestedSchema).build();
+
+    Struct nestedStruct = new Struct(nestedSchema).put("field1", "value1").put("field2", 42);
+
+    Struct struct = new Struct(schema).put("nested", nestedStruct);
+
+    Object result = Utils.extractValue(struct, new String[] {"nested", "field1"});
+    assertEquals("value1", result);
+  }
+}

--- a/src/test/java/io/lenses/connect/smt/header/UtilsIsBlankTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsIsBlankTest.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/io/lenses/connect/smt/header/UtilsIsBlankTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsIsBlankTest.java
@@ -1,0 +1,23 @@
+package io.lenses.connect.smt.header;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class UtilsIsBlankTest {
+  @Test
+  public void isBlankReturnsTrueWhenStringIsNull() {
+    assertTrue(Utils.isBlank(null));
+  }
+
+  @Test
+  public void isBlankReturnsTrueWhenStringIsEmpty() {
+    assertTrue(Utils.isBlank(""));
+  }
+
+  @Test
+  public void isBlankReturnsFalseWhenStringIsNotBlank() {
+    assertFalse(Utils.isBlank("not blank"));
+  }
+}


### PR DESCRIPTION
This PR introduces a new SMT which allows picking a field from the payload and use it as source for introducing the headers for time-based object key values in Lenses datalakes connectors