### PR TITLE
Support for multiple source timestamp formats

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Build
         run: mvn clean package -B
 
+      - name: Test
+        run: mvn test
+
       - name: Create JAR
         run: mvn jar:jar
 

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeaders.java
@@ -25,7 +25,7 @@ public class InsertRollingFieldTimestampHeaders<R extends ConnectRecord<R>>
     extends InsertRollingTimestampHeaders<R> {
   private RecordFieldTimestamp<R> fieldTimestamp;
 
-  public static ConfigDef CONFIG_DEF;
+  public static final ConfigDef CONFIG_DEF;
 
   static {
     // The code would be

--- a/src/main/java/io/lenses/connect/smt/header/InsertRollingTimestampHeaders.java
+++ b/src/main/java/io/lenses/connect/smt/header/InsertRollingTimestampHeaders.java
@@ -27,7 +27,7 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 abstract class InsertRollingTimestampHeaders<R extends ConnectRecord<R>>
     extends InsertTimestampHeaders<R> {
 
-  public static ConfigDef CONFIG_DEF =
+  public static final ConfigDef CONFIG_DEF =
       InsertTimestampHeaders.CONFIG_DEF
           .define(
               ConfigName.ROLLING_WINDOW_SIZE_CONFIG,

--- a/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
@@ -1,0 +1,88 @@
+package io.lenses.connect.smt.header;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+class MultiDateTimeFormatter {
+
+    private List<DateTimeFormatter> formatters;
+    private List<String> patterns;
+    private Boolean returnNowIfNull;
+
+    public MultiDateTimeFormatter(
+            List<String> patterns,
+            List<DateTimeFormatter> formatters,
+            Boolean returnNowIfNull
+    ) {
+        this.patterns = patterns;
+        this.formatters = formatters;
+        this.returnNowIfNull = returnNowIfNull;
+    }
+
+    public Instant format(String value, ZoneId zoneId) {
+        if (value == null && returnNowIfNull) {
+            return LocalDateTime.now().atZone(zoneId).toInstant();
+        }
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                LocalDateTime localDateTime = LocalDateTime.parse( value, formatter);
+                return localDateTime.atZone(zoneId).toInstant();
+            } catch (DateTimeParseException dtpe) {
+                // ignore exception and use fallback
+            }
+        }
+        throw new DateTimeParseException("Cannot parse date with any formats", value, 0);
+    }
+
+
+    public String getDisplayPatterns() {
+        return String.join(", ", patterns);
+    }
+
+
+    private static DateTimeFormatter createFormatter(String pattern, String configName, Locale locale, ZoneId zoneId) {
+    try {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        if (locale != null) {
+            formatter = formatter.withLocale(locale);
+        }
+        if (zoneId != null) {
+            formatter = formatter.withZone(zoneId);
+        }
+        return formatter;
+    } catch (IllegalArgumentException e) {
+        throw new ConfigException("Configuration '" + configName + "' is not a valid date format.");
+    }
+}
+
+public static MultiDateTimeFormatter createDateTimeFormatter(
+        List<String> patternConfigs, String configName, Locale locale) {
+
+    return new MultiDateTimeFormatter(
+            patternConfigs,
+            patternConfigs.stream()
+                    .map(patternConfig -> createFormatter(patternConfig, configName, locale, null))
+                    .collect(Collectors.toUnmodifiableList()),
+            false
+    );
+}
+
+public static MultiDateTimeFormatter createDateTimeFormatter(
+        List<String> patternConfigs, String configName, ZoneId zoneId) {
+
+    return new MultiDateTimeFormatter(
+            patternConfigs,
+            patternConfigs.stream()
+                    .map(patternConfig -> createFormatter(patternConfig, configName, null, zoneId))
+                    .collect(Collectors.toUnmodifiableList()),
+            true);
+}
+}

--- a/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
@@ -39,7 +39,6 @@ class MultiDateTimeFormatter {
                 return localDateTime.atZone(zoneId).toInstant();
             } catch (DateTimeParseException dtpe) {
                 // ignore exception and use fallback
-                System.err.println("ERROR: " + dtpe.getMessage());
             }
         }
         throw new DateTimeParseException("Cannot parse date with any formats", value, 0);

--- a/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
@@ -30,6 +30,8 @@ class MultiDateTimeFormatter {
     public Instant format(String value, ZoneId zoneId) {
         if (value == null && returnNowIfNull) {
             return LocalDateTime.now().atZone(zoneId).toInstant();
+        } else if (value == null) {
+            throw new DateTimeParseException("No valid date time provided", "null", 0);
         }
         for (DateTimeFormatter formatter : formatters) {
             try {

--- a/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
@@ -13,9 +13,9 @@ import java.util.stream.Collectors;
 
 class MultiDateTimeFormatter {
 
-    private List<DateTimeFormatter> formatters;
-    private List<String> patterns;
-    private Boolean returnNowIfNull;
+    private final List<DateTimeFormatter> formatters;
+    private final List<String> patterns;
+    private final Boolean returnNowIfNull;
 
     public MultiDateTimeFormatter(
             List<String> patterns,
@@ -37,6 +37,7 @@ class MultiDateTimeFormatter {
                 return localDateTime.atZone(zoneId).toInstant();
             } catch (DateTimeParseException dtpe) {
                 // ignore exception and use fallback
+                System.err.println("ERROR: " + dtpe.getMessage());
             }
         }
         throw new DateTimeParseException("Cannot parse date with any formats", value, 0);

--- a/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/MultiDateTimeFormatter.java
@@ -1,6 +1,14 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
-
-import org.apache.kafka.common.config.ConfigException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -10,81 +18,77 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigException;
 
 class MultiDateTimeFormatter {
 
-    private final List<DateTimeFormatter> formatters;
-    private final List<String> patterns;
-    private final Boolean returnNowIfNull;
+  private final List<DateTimeFormatter> formatters;
+  private final List<String> patterns;
+  private final Boolean returnNowIfNull;
 
-    public MultiDateTimeFormatter(
-            List<String> patterns,
-            List<DateTimeFormatter> formatters,
-            Boolean returnNowIfNull
-    ) {
-        this.patterns = patterns;
-        this.formatters = formatters;
-        this.returnNowIfNull = returnNowIfNull;
+  public MultiDateTimeFormatter(
+      List<String> patterns, List<DateTimeFormatter> formatters, Boolean returnNowIfNull) {
+    this.patterns = patterns;
+    this.formatters = formatters;
+    this.returnNowIfNull = returnNowIfNull;
+  }
+
+  public Instant format(String value, ZoneId zoneId) {
+    if (value == null && returnNowIfNull) {
+      return LocalDateTime.now().atZone(zoneId).toInstant();
+    } else if (value == null) {
+      throw new DateTimeParseException("No valid date time provided", "null", 0);
     }
-
-    public Instant format(String value, ZoneId zoneId) {
-        if (value == null && returnNowIfNull) {
-            return LocalDateTime.now().atZone(zoneId).toInstant();
-        } else if (value == null) {
-            throw new DateTimeParseException("No valid date time provided", "null", 0);
-        }
-        for (DateTimeFormatter formatter : formatters) {
-            try {
-                LocalDateTime localDateTime = LocalDateTime.parse( value, formatter);
-                return localDateTime.atZone(zoneId).toInstant();
-            } catch (DateTimeParseException dtpe) {
-                // ignore exception and use fallback
-            }
-        }
-        throw new DateTimeParseException("Cannot parse date with any formats", value, 0);
+    for (DateTimeFormatter formatter : formatters) {
+      try {
+        LocalDateTime localDateTime = LocalDateTime.parse(value, formatter);
+        return localDateTime.atZone(zoneId).toInstant();
+      } catch (DateTimeParseException dtpe) {
+        // ignore exception and use fallback
+      }
     }
+    throw new DateTimeParseException("Cannot parse date with any formats", value, 0);
+  }
 
+  public String getDisplayPatterns() {
+    return String.join(", ", patterns);
+  }
 
-    public String getDisplayPatterns() {
-        return String.join(", ", patterns);
-    }
-
-
-    private static DateTimeFormatter createFormatter(String pattern, String configName, Locale locale, ZoneId zoneId) {
+  private static DateTimeFormatter createFormatter(
+      String pattern, String configName, Locale locale, ZoneId zoneId) {
     try {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
-        if (locale != null) {
-            formatter = formatter.withLocale(locale);
-        }
-        if (zoneId != null) {
-            formatter = formatter.withZone(zoneId);
-        }
-        return formatter;
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+      if (locale != null) {
+        formatter = formatter.withLocale(locale);
+      }
+      if (zoneId != null) {
+        formatter = formatter.withZone(zoneId);
+      }
+      return formatter;
     } catch (IllegalArgumentException e) {
-        throw new ConfigException("Configuration '" + configName + "' is not a valid date format.");
+      throw new ConfigException("Configuration '" + configName + "' is not a valid date format.");
     }
-}
+  }
 
-public static MultiDateTimeFormatter createDateTimeFormatter(
-        List<String> patternConfigs, String configName, Locale locale) {
-
-    return new MultiDateTimeFormatter(
-            patternConfigs,
-            patternConfigs.stream()
-                    .map(patternConfig -> createFormatter(patternConfig, configName, locale, null))
-                    .collect(Collectors.toUnmodifiableList()),
-            false
-    );
-}
-
-public static MultiDateTimeFormatter createDateTimeFormatter(
-        List<String> patternConfigs, String configName, ZoneId zoneId) {
+  public static MultiDateTimeFormatter createDateTimeFormatter(
+      List<String> patternConfigs, String configName, Locale locale) {
 
     return new MultiDateTimeFormatter(
-            patternConfigs,
-            patternConfigs.stream()
-                    .map(patternConfig -> createFormatter(patternConfig, configName, null, zoneId))
-                    .collect(Collectors.toUnmodifiableList()),
-            true);
-}
+        patternConfigs,
+        patternConfigs.stream()
+            .map(patternConfig -> createFormatter(patternConfig, configName, locale, null))
+            .collect(Collectors.toUnmodifiableList()),
+        false);
+  }
+
+  public static MultiDateTimeFormatter createDateTimeFormatter(
+      List<String> patternConfigs, String configName, ZoneId zoneId) {
+
+    return new MultiDateTimeFormatter(
+        patternConfigs,
+        patternConfigs.stream()
+            .map(patternConfig -> createFormatter(patternConfig, configName, null, zoneId))
+            .collect(Collectors.toUnmodifiableList()),
+        true);
+  }
 }

--- a/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
@@ -12,6 +12,9 @@ package io.lenses.connect.smt.header;
 
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
+import java.util.Comparator;
+import java.util.Map;
+
 /**
  * This class is responsible for formatting properties from a SimpleConfig object.
  * It converts the properties into a string representation in a json-like format.
@@ -38,7 +41,7 @@ public class PropsFormatter {
      */
     public String apply() {
         StringBuilder sb = new StringBuilder("{");
-        simpleConfig.originalsStrings().forEach((k, v) -> sb.append(k).append(": \"").append(v).append("\", "));
+        simpleConfig.originalsStrings().entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach((entry) -> sb.append(entry.getKey()).append(": \"").append(entry.getValue()).append("\", "));
         sb.delete(sb.length() - 2, sb.length());
         return sb.append("}").toString();
     }

--- a/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
@@ -41,7 +41,7 @@ public class PropsFormatter {
      */
     public String apply() {
         StringBuilder sb = new StringBuilder("{");
-        simpleConfig.originalsStrings().entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach((entry) -> sb.append(entry.getKey()).append(": \"").append(entry.getValue()).append("\", "));
+        simpleConfig.originalsStrings().entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> sb.append(entry.getKey()).append(": \"").append(entry.getValue()).append("\", "));
         sb.delete(sb.length() - 2, sb.length());
         return sb.append("}").toString();
     }

--- a/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
+++ b/src/main/java/io/lenses/connect/smt/header/PropsFormatter.java
@@ -10,39 +10,41 @@
  */
 package io.lenses.connect.smt.header;
 
+import java.util.Map;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-import java.util.Comparator;
-import java.util.Map;
-
 /**
- * This class is responsible for formatting properties from a SimpleConfig object.
- * It converts the properties into a string representation in a json-like format.
+ * This class is responsible for formatting properties from a SimpleConfig object. It converts the
+ * properties into a string representation in a json-like format.
  */
 public class PropsFormatter {
 
-    private final SimpleConfig simpleConfig;
+  private final SimpleConfig simpleConfig;
 
-    /**
-     * Constructs a new PropsFormatter with the given SimpleConfig.
-     *
-     * @param simpleConfig the SimpleConfig object containing the properties to be formatted
-     */
-    public PropsFormatter(SimpleConfig simpleConfig) {
-        this.simpleConfig = simpleConfig;
-    }
+  /**
+   * Constructs a new PropsFormatter with the given SimpleConfig.
+   *
+   * @param simpleConfig the SimpleConfig object containing the properties to be formatted
+   */
+  public PropsFormatter(SimpleConfig simpleConfig) {
+    this.simpleConfig = simpleConfig;
+  }
 
-    /**
-     * Formats the properties from the SimpleConfig object into a string.
-     * The properties are represented as key-value pairs in the format: "key: "value"".
-     * All properties are enclosed in curly braces.
-     *
-     * @return a string representation of the properties
-     */
-    public String apply() {
-        StringBuilder sb = new StringBuilder("{");
-        simpleConfig.originalsStrings().entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> sb.append(entry.getKey()).append(": \"").append(entry.getValue()).append("\", "));
-        sb.delete(sb.length() - 2, sb.length());
-        return sb.append("}").toString();
-    }
+  /**
+   * Formats the properties from the SimpleConfig object into a string. The properties are
+   * represented as key-value pairs in the format: "key: "value"". All properties are enclosed in
+   * curly braces.
+   *
+   * @return a string representation of the properties
+   */
+  public String apply() {
+    StringBuilder sb = new StringBuilder("{");
+    simpleConfig.originalsStrings().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            entry ->
+                sb.append(entry.getKey()).append(": \"").append(entry.getValue()).append("\", "));
+    sb.delete(sb.length() - 2, sb.length());
+    return sb.append("}").toString();
+  }
 }

--- a/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
+++ b/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
@@ -21,7 +21,6 @@ import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
@@ -110,7 +109,8 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
                 + " instead.");
       }
 
-      return convertToTimestamp(extractedValue, unixPrecision, fromPattern, timeZone, propsFormatter);
+      return convertToTimestamp(
+          extractedValue, unixPrecision, fromPattern, timeZone, propsFormatter);
     }
   }
 
@@ -155,7 +155,12 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
                     MultiDateTimeFormatter.createDateTimeFormatter(
                         patterns, FORMAT_FROM_CONFIG, locale));
 
-    return new RecordFieldTimestamp<>(fieldTypeAndFields, fromPattern, unixPrecision, zoneId, Optional.of(new PropsFormatter(config)));
+    return new RecordFieldTimestamp<>(
+        fieldTypeAndFields,
+        fromPattern,
+        unixPrecision,
+        zoneId,
+        Optional.of(new PropsFormatter(config)));
   }
 
   public static ConfigDef extendConfigDef(ConfigDef from) {

--- a/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
+++ b/src/main/java/io/lenses/connect/smt/header/RecordFieldTimestamp.java
@@ -40,7 +40,7 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
   public static final String UNIX_PRECISION_CONFIG = "unix.precision";
   private static final String UNIX_PRECISION_DEFAULT = "milliseconds";
   private final FieldTypeUtils.FieldTypeAndFields fieldTypeAndFields;
-  private final Optional<DateTimeFormatter> fromPattern;
+  private final Optional<MultiDateTimeFormatter> fromPattern;
   private final String unixPrecision;
   private final ZoneId timeZone;
 
@@ -48,7 +48,7 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
 
   private RecordFieldTimestamp(
       FieldTypeUtils.FieldTypeAndFields fieldTypeAndFields,
-      Optional<DateTimeFormatter> fromPattern,
+      Optional<MultiDateTimeFormatter> fromPattern,
       String unixPrecision,
       ZoneId timeZone,
       Optional<PropsFormatter> propsFormatter) {
@@ -62,10 +62,6 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
 
   public FieldTypeUtils.FieldTypeAndFields getFieldTypeAndFields() {
     return fieldTypeAndFields;
-  }
-
-  public Optional<DateTimeFormatter> getFromPattern() {
-    return fromPattern;
   }
 
   public String getUnixPrecision() {
@@ -152,12 +148,12 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
     final String unixPrecision =
         Optional.ofNullable(config.getString(UNIX_PRECISION_CONFIG)).orElse(UNIX_PRECISION_DEFAULT);
 
-    final Optional<DateTimeFormatter> fromPattern =
-        Optional.ofNullable(config.getString(FORMAT_FROM_CONFIG))
+    final Optional<MultiDateTimeFormatter> fromPattern =
+        Optional.ofNullable(config.getList(FORMAT_FROM_CONFIG))
             .map(
-                pattern ->
-                    InsertTimestampHeaders.createDateTimeFormatter(
-                        pattern, FORMAT_FROM_CONFIG, locale));
+                patterns ->
+                    MultiDateTimeFormatter.createDateTimeFormatter(
+                        patterns, FORMAT_FROM_CONFIG, locale));
 
     return new RecordFieldTimestamp<>(fieldTypeAndFields, fromPattern, unixPrecision, zoneId, Optional.of(new PropsFormatter(config)));
   }
@@ -179,7 +175,7 @@ class RecordFieldTimestamp<R extends ConnectRecord<R>> {
                 + "'.")
         .define(
             FORMAT_FROM_CONFIG,
-            ConfigDef.Type.STRING,
+            ConfigDef.Type.LIST,
             null,
             ConfigDef.Importance.MEDIUM,
             "A DateTimeFormatter-compatible format for the timestamp. Used to parse the"

--- a/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
+++ b/src/main/java/io/lenses/connect/smt/header/TimestampConverter.java
@@ -430,10 +430,12 @@ public final class TimestampConverter<R extends ConnectRecord<R>> implements Tra
       throw new ConfigException("TimestampConverter requires header key to be specified");
     }
 
-    MultiDateTimeFormatter fromPattern = Optional
-            .ofNullable(simpleConfig.getList(FORMAT_FROM_CONFIG))
-            .map(fromFormatPattern -> MultiDateTimeFormatter.createDateTimeFormatter(
-                    fromFormatPattern, FORMAT_FROM_CONFIG, Constants.UTC.toZoneId()))
+    MultiDateTimeFormatter fromPattern =
+        Optional.ofNullable(simpleConfig.getList(FORMAT_FROM_CONFIG))
+            .map(
+                fromFormatPattern ->
+                    MultiDateTimeFormatter.createDateTimeFormatter(
+                        fromFormatPattern, FORMAT_FROM_CONFIG, Constants.UTC.toZoneId()))
             .orElse(null);
 
     String toFormatPattern = simpleConfig.getString(FORMAT_TO_CONFIG);

--- a/src/main/java/io/lenses/connect/smt/header/Utils.java
+++ b/src/main/java/io/lenses/connect/smt/header/Utils.java
@@ -33,12 +33,8 @@ import org.apache.kafka.connect.errors.DataException;
 
 class Utils {
 
-  static Instant convertToTimestamp(
-          Object value, String unixPrecision, Optional<DateTimeFormatter> fromPattern, ZoneId zoneId) {
-    return convertToTimestamp(value, unixPrecision, fromPattern, zoneId, Optional.empty());
-  }
     static Instant convertToTimestamp(
-          Object value, String unixPrecision, Optional<DateTimeFormatter> fromPattern, ZoneId zoneId, Optional<PropsFormatter> propsFormatter) {
+          Object value, String unixPrecision, Optional<MultiDateTimeFormatter> fromPattern, ZoneId zoneId, Optional<PropsFormatter> propsFormatter) {
     if (value == null) {
       return Instant.now();
     }
@@ -63,8 +59,7 @@ class Utils {
           .map(
               pattern -> {
                 try {
-                  final LocalDateTime localDateTime = LocalDateTime.parse((String) value, pattern);
-                  return localDateTime.atZone(zoneId).toInstant();
+                  return pattern.format((String) value, zoneId);
                 } catch (Exception e) {
                   throw new DataException(
                       "Could not parse the string timestamp: "

--- a/src/main/java/io/lenses/connect/smt/header/Utils.java
+++ b/src/main/java/io/lenses/connect/smt/header/Utils.java
@@ -17,7 +17,6 @@ import static io.lenses.connect.smt.header.UnixPrecisionConstants.UNIX_PRECISION
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
@@ -33,8 +31,12 @@ import org.apache.kafka.connect.errors.DataException;
 
 class Utils {
 
-    static Instant convertToTimestamp(
-          Object value, String unixPrecision, Optional<MultiDateTimeFormatter> fromPattern, ZoneId zoneId, Optional<PropsFormatter> propsFormatter) {
+  static Instant convertToTimestamp(
+      Object value,
+      String unixPrecision,
+      Optional<MultiDateTimeFormatter> fromPattern,
+      ZoneId zoneId,
+      Optional<PropsFormatter> propsFormatter) {
     if (value == null) {
       return Instant.now();
     }
@@ -74,7 +76,13 @@ class Utils {
                 try {
                   return Instant.ofEpochMilli(Long.parseLong((String) value));
                 } catch (NumberFormatException e) {
-                  throw new DataException("Expected a long, but found " + value + ". Props: " + propsFormatter.map(PropsFormatter::apply).orElse("(No props formatter)"));
+                  throw new DataException(
+                      "Expected a long, but found "
+                          + value
+                          + ". Props: "
+                          + propsFormatter
+                              .map(PropsFormatter::apply)
+                              .orElse("(No props formatter)"));
                 }
               });
     }

--- a/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/ConvertToTimestampTest.java
@@ -27,8 +27,8 @@ class ConvertToTimestampTest {
   @Test
   void convertToTimestampReturnsCurrentTimeWhenValueIsNull() {
     Instant result =
-        Utils.convertToTimestamp(null, "seconds", Optional.empty(), ZoneId.systemDefault(),                Optional.empty()
-        );
+        Utils.convertToTimestamp(
+            null, "seconds", Optional.empty(), ZoneId.systemDefault(), Optional.empty());
     assertNotNull(result);
   }
 
@@ -36,7 +36,8 @@ class ConvertToTimestampTest {
   void convertToTimestampReturnsSameInstantWhenValueIsInstant() {
     Instant instant = Instant.now();
     Instant result =
-        Utils.convertToTimestamp(instant, "seconds", Optional.empty(), ZoneId.systemDefault(), Optional.empty());
+        Utils.convertToTimestamp(
+            instant, "seconds", Optional.empty(), ZoneId.systemDefault(), Optional.empty());
     assertEquals(instant, result);
   }
 
@@ -44,7 +45,8 @@ class ConvertToTimestampTest {
   void convertToTimestampReturnsCorrectInstantWhenValueIsLong() {
     long value = 1633097000L; // corresponds to 2021-10-01T11:30:00Z
     Instant result =
-        Utils.convertToTimestamp(value, "seconds", Optional.empty(), ZoneId.systemDefault(), Optional.empty());
+        Utils.convertToTimestamp(
+            value, "seconds", Optional.empty(), ZoneId.systemDefault(), Optional.empty());
     assertEquals(Instant.ofEpochSecond(value), result);
   }
 
@@ -53,19 +55,13 @@ class ConvertToTimestampTest {
     String value = "2021-10-01T11:30:00Z";
     Instant result =
         Utils.convertToTimestamp(
-            value,
-            "seconds",
-            Optional.of(createMultiDateTimeFormatter()),
-            UTC,
-                Optional.empty());
+            value, "seconds", Optional.of(createMultiDateTimeFormatter()), UTC, Optional.empty());
     assertEquals(Instant.parse(value), result);
   }
 
   private static MultiDateTimeFormatter createMultiDateTimeFormatter() {
     return MultiDateTimeFormatter.createDateTimeFormatter(
-            List.of("yyyy-MM-dd'T'HH:mm:ssZZZZZ"),
-            "Unit test",
-            UTC);
+        List.of("yyyy-MM-dd'T'HH:mm:ssZZZZZ"), "Unit test", UTC);
   }
 
   @Test
@@ -74,11 +70,7 @@ class ConvertToTimestampTest {
     assertThrows(
         DataException.class,
         () ->
-            convertToTimestamp(
-                value,
-                "seconds",
-                Optional.of(createMultiDateTimeFormatter()),
-                    UTC));
+            convertToTimestamp(value, "seconds", Optional.of(createMultiDateTimeFormatter()), UTC));
   }
 
   @Test
@@ -110,14 +102,15 @@ class ConvertToTimestampTest {
   @Test
   void convertToTimestampReturnsCorrectInstantWhenValueIsEpochAndPrecisionIsSeconds() {
     Long value = 1633097000L; // corresponds to 2021-10-01T11:30:00Z
-    Instant result =
-        convertToTimestamp(value, "seconds", Optional.empty(), ZoneId.systemDefault());
+    Instant result = convertToTimestamp(value, "seconds", Optional.empty(), ZoneId.systemDefault());
     assertEquals(Instant.ofEpochSecond(1633097000L, 0), result);
   }
 
-
   static Instant convertToTimestamp(
-          Object value, String unixPrecision, Optional<MultiDateTimeFormatter> fromPattern, ZoneId zoneId) {
+      Object value,
+      String unixPrecision,
+      Optional<MultiDateTimeFormatter> fromPattern,
+      ZoneId zoneId) {
     return Utils.convertToTimestamp(value, unixPrecision, fromPattern, zoneId, Optional.empty());
   }
 }

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
@@ -13,8 +13,10 @@ package io.lenses.connect.smt.header;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
@@ -23,10 +25,10 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link InsertRollingRecordTimestampHeaders}. */
-public class InsertRollingFieldTimestampHeadersTest {
+class InsertRollingFieldTimestampHeadersTest {
 
   @Test
-  public void testRollingWindowEvery15Minutes() {
+  void testRollingWindowEvery15Minutes() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
 
     scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"));
@@ -75,7 +77,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testRollingWindowEvery15MinutesAndTimezoneSetToKalkota() {
+  void testRollingWindowEvery15MinutesAndTimezoneSetToKalkota() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
 
     // the first param to the Tuple5 is UTC. the third, fourth and figth arguments should be adapted
@@ -126,7 +128,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testRollingWindowEvery15MinutesAndTimezoneIsParis() {
+  void testRollingWindowEvery15MinutesAndTimezoneIsParis() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
 
     scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 02:00", "02", "00"));
@@ -182,7 +184,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testRollingWindowEvery5Minutes() {
+  void testRollingWindowEvery5Minutes() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
 
     scenarios.add(new Tuple5<>(("2020-01-01T01:00:00.999Z"), 5, "2020-01-01 01:00", "01", "00"));
@@ -256,7 +258,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testFormattedWithRollingWindowOf1Hour() {
+  void testFormattedWithRollingWindowOf1Hour() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
     scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 1, "2020-01-01 01:00", "01", "00"));
     scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 1, "2020-01-01 01:00", "01", "00"));
@@ -295,7 +297,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testRollingWindowOf3Hours() {
+  void testRollingWindowOf3Hours() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
     scenarios.add(new Tuple5<>(("2020-01-01T01:19:59.999Z"), 3, "2020-01-01 00:00", "00", "00"));
     scenarios.add(new Tuple5<>(("2020-01-01T01:20:00.000Z"), 3, "2020-01-01 00:00", "00", "00"));
@@ -340,7 +342,7 @@ public class InsertRollingFieldTimestampHeadersTest {
   }
 
   @Test
-  public void testRollingWindowEvery12Seconds() {
+  void testRollingWindowEvery12Seconds() {
     ArrayList<Tuple5<String, Integer, String, String, String>> scenarios = new ArrayList<>();
     scenarios.add(
         new Tuple5<>(("2020-01-01T01:19:59.000Z"), 12, "2020-01-01 01:19:48", "19", "48"));
@@ -403,7 +405,62 @@ public class InsertRollingFieldTimestampHeadersTest {
         });
   }
 
-  static class Tuple5<A, B, C, D, E> {
+    @Test
+    void testMultipleDateFormats() {
+        // one format with millis, one without.  Do we fallback to the backup format?
+        String pattern1 = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+        String pattern2 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+        List<Tuple5<String, Integer, String, String, String>> scenarios = List.of(
+                new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"),
+                new Tuple5<>(("2020-01-01T01:00:01Z"), 15, "2020-01-01 01:00", "01", "00"),
+                new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"),
+                new Tuple5<>(("2020-01-01T01:15:00Z"), 15, "2020-01-01 01:15", "01", "15"),
+                new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"),
+                new Tuple5<>(("2020-01-01T01:29:59Z"), 15, "2020-01-01 01:15", "01", "15"),
+                new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"),
+                new Tuple5<>(("2020-01-01T01:30:01Z"), 15, "2020-01-01 01:30", "01", "30"),
+                new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"),
+                new Tuple5<>(("2020-01-01T01:45:00Z"), 15, "2020-01-01 01:45", "01", "45"),
+                new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"),
+                new Tuple5<>(("2020-01-01T01:59:59Z"), 15, "2020-01-01 01:45", "01", "45")
+        );
+        scenarios.forEach(
+                scenario -> {
+                    Map<String, String> configs = Map.of(
+                            "header.prefix.name", "wallclock_",
+                            "date.format", "yyyy-MM-dd HH:mm",
+                            "format.from.pattern", pattern1 + "," + pattern2,
+                            "window.size", scenario.second.toString(),
+                            "window.type", "minutes",
+                            "field", "_value"
+                    );
+
+                    final SourceRecord transformed;
+                    try (InsertRollingFieldTimestampHeaders<SourceRecord> transformer = new InsertRollingFieldTimestampHeaders<>()) {
+                        transformer.configure(configs);
+
+                        transformed = transformer.apply(
+                                new SourceRecord(
+                                null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, scenario.first, 0L, new ConnectHeaders())
+                        );
+                    }
+                    final String actualDate =
+                            transformed.headers().lastWithName("wallclock_date").value().toString();
+                    assertEquals(actualDate, scenario.third);
+
+                    final String actualHour =
+                            transformed.headers().lastWithName("wallclock_hour").value().toString();
+                    assertEquals(actualHour, scenario.fourth);
+
+                    final String actualMinute =
+                            transformed.headers().lastWithName("wallclock_minute").value().toString();
+                    assertEquals(actualMinute, scenario.fifth);
+                });
+    }
+
+
+    static class Tuple5<A, B, C, D, E> {
     private final A first;
     private final B second;
     private final C third;

--- a/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/InsertRollingFieldTimestampHeadersTest.java
@@ -13,7 +13,6 @@ package io.lenses.connect.smt.header;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -405,62 +404,71 @@ class InsertRollingFieldTimestampHeadersTest {
         });
   }
 
-    @Test
-    void testMultipleDateFormats() {
-        // one format with millis, one without.  Do we fallback to the backup format?
-        String pattern1 = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-        String pattern2 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  @Test
+  void testMultipleDateFormats() {
+    // one format with millis, one without.  Do we fallback to the backup format?
+    String pattern1 = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    String pattern2 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
-        List<Tuple5<String, Integer, String, String, String>> scenarios = List.of(
-                new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"),
-                new Tuple5<>(("2020-01-01T01:00:01Z"), 15, "2020-01-01 01:00", "01", "00"),
-                new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"),
-                new Tuple5<>(("2020-01-01T01:15:00Z"), 15, "2020-01-01 01:15", "01", "15"),
-                new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"),
-                new Tuple5<>(("2020-01-01T01:29:59Z"), 15, "2020-01-01 01:15", "01", "15"),
-                new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"),
-                new Tuple5<>(("2020-01-01T01:30:01Z"), 15, "2020-01-01 01:30", "01", "30"),
-                new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"),
-                new Tuple5<>(("2020-01-01T01:45:00Z"), 15, "2020-01-01 01:45", "01", "45"),
-                new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"),
-                new Tuple5<>(("2020-01-01T01:59:59Z"), 15, "2020-01-01 01:45", "01", "45")
-        );
-        scenarios.forEach(
-                scenario -> {
-                    Map<String, String> configs = Map.of(
-                            "header.prefix.name", "wallclock_",
-                            "date.format", "yyyy-MM-dd HH:mm",
-                            "format.from.pattern", pattern1 + "," + pattern2,
-                            "window.size", scenario.second.toString(),
-                            "window.type", "minutes",
-                            "field", "_value"
-                    );
+    List<Tuple5<String, Integer, String, String, String>> scenarios =
+        List.of(
+            new Tuple5<>(("2020-01-01T01:00:00.999Z"), 15, "2020-01-01 01:00", "01", "00"),
+            new Tuple5<>(("2020-01-01T01:00:01Z"), 15, "2020-01-01 01:00", "01", "00"),
+            new Tuple5<>(("2020-01-01T01:14:59.000Z"), 15, "2020-01-01 01:00", "01", "00"),
+            new Tuple5<>(("2020-01-01T01:15:00Z"), 15, "2020-01-01 01:15", "01", "15"),
+            new Tuple5<>(("2020-01-01T01:15:01.000Z"), 15, "2020-01-01 01:15", "01", "15"),
+            new Tuple5<>(("2020-01-01T01:29:59Z"), 15, "2020-01-01 01:15", "01", "15"),
+            new Tuple5<>(("2020-01-01T01:30:00.000Z"), 15, "2020-01-01 01:30", "01", "30"),
+            new Tuple5<>(("2020-01-01T01:30:01Z"), 15, "2020-01-01 01:30", "01", "30"),
+            new Tuple5<>(("2020-01-01T01:44:59.000Z"), 15, "2020-01-01 01:30", "01", "30"),
+            new Tuple5<>(("2020-01-01T01:45:00Z"), 15, "2020-01-01 01:45", "01", "45"),
+            new Tuple5<>(("2020-01-01T01:45:01.000Z"), 15, "2020-01-01 01:45", "01", "45"),
+            new Tuple5<>(("2020-01-01T01:59:59Z"), 15, "2020-01-01 01:45", "01", "45"));
+    scenarios.forEach(
+        scenario -> {
+          Map<String, String> configs =
+              Map.of(
+                  "header.prefix.name", "wallclock_",
+                  "date.format", "yyyy-MM-dd HH:mm",
+                  "format.from.pattern", pattern1 + "," + pattern2,
+                  "window.size", scenario.second.toString(),
+                  "window.type", "minutes",
+                  "field", "_value");
 
-                    final SourceRecord transformed;
-                    try (InsertRollingFieldTimestampHeaders<SourceRecord> transformer = new InsertRollingFieldTimestampHeaders<>()) {
-                        transformer.configure(configs);
+          final SourceRecord transformed;
+          try (InsertRollingFieldTimestampHeaders<SourceRecord> transformer =
+              new InsertRollingFieldTimestampHeaders<>()) {
+            transformer.configure(configs);
 
-                        transformed = transformer.apply(
-                                new SourceRecord(
-                                null, null, "topic", 0, Schema.STRING_SCHEMA, "key", null, scenario.first, 0L, new ConnectHeaders())
-                        );
-                    }
-                    final String actualDate =
-                            transformed.headers().lastWithName("wallclock_date").value().toString();
-                    assertEquals(actualDate, scenario.third);
+            transformed =
+                transformer.apply(
+                    new SourceRecord(
+                        null,
+                        null,
+                        "topic",
+                        0,
+                        Schema.STRING_SCHEMA,
+                        "key",
+                        null,
+                        scenario.first,
+                        0L,
+                        new ConnectHeaders()));
+          }
+          final String actualDate =
+              transformed.headers().lastWithName("wallclock_date").value().toString();
+          assertEquals(actualDate, scenario.third);
 
-                    final String actualHour =
-                            transformed.headers().lastWithName("wallclock_hour").value().toString();
-                    assertEquals(actualHour, scenario.fourth);
+          final String actualHour =
+              transformed.headers().lastWithName("wallclock_hour").value().toString();
+          assertEquals(actualHour, scenario.fourth);
 
-                    final String actualMinute =
-                            transformed.headers().lastWithName("wallclock_minute").value().toString();
-                    assertEquals(actualMinute, scenario.fifth);
-                });
-    }
+          final String actualMinute =
+              transformed.headers().lastWithName("wallclock_minute").value().toString();
+          assertEquals(actualMinute, scenario.fifth);
+        });
+  }
 
-
-    static class Tuple5<A, B, C, D, E> {
+  static class Tuple5<A, B, C, D, E> {
     private final A first;
     private final B second;
     private final C third;

--- a/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
@@ -74,4 +74,41 @@ class MultiDateTimeFormatterTest {
         String result = formatter.getDisplayPatterns();
         assertEquals(expected, result);
     }
+
+    @Test
+void testFormatWithEmptyListOfDateStrings() {
+    MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
+            List.of(),
+            List.of(),
+            false
+    );
+
+    assertThrows(DateTimeParseException.class, () -> formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC")));
+}
+
+@Test
+void testFormatWithMultiplePatternsTargetingFirst() {
+    MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            "TestConfig",
+            ZoneId.of("UTC")
+    );
+
+    Instant expected = Instant.parse("2021-10-01T11:30:00Z");
+    Instant result = formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC"));
+    assertEquals(expected, result);
+}
+
+@Test
+void testFormatWithMultiplePatternsTargetingSecond() {
+    MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            "TestConfig",
+            ZoneId.of("UTC")
+    );
+
+    Instant expected = Instant.parse("2021-10-01T11:30:00Z");
+    Instant result = formatter.format("2021-10-01 11:30:00", ZoneId.of("UTC"));
+    assertEquals(expected, result);
+}
 }

--- a/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
@@ -1,114 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at: http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
 package io.lenses.connect.smt.header;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class MultiDateTimeFormatterTest {
 
-    @Test
-    void testFormatWithValidDateString() {
-        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
-                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
-                "TestConfig",
-                ZoneId.of("UTC")
-        );
-
-        Instant expected = Instant.parse("2021-10-01T11:30:00Z");
-        Instant result = formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC"));
-        assertEquals(expected, result);
-    }
-
-    @Test
-    void testFormatWithInvalidDateString() {
-        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
-                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
-                "TestConfig",
-                ZoneId.of("UTC")
-        );
-
-        assertThrows(DateTimeParseException.class, () -> {
-            formatter.format("invalid-date", ZoneId.of("UTC"));
-        });
-    }
-
-    @Test
-    void testFormatWithNullValueAndReturnNowIfNullTrue() {
-        MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
-                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
-                List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
-                true
-        );
-
-        Instant result = formatter.format(null, ZoneId.of("UTC"));
-        assertNotNull(result);
-    }
-
-    @Test
-    void testFormatWithNullValueAndReturnNowIfNullFalse() {
-        MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
-                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
-                List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
-                false
-        );
-
-        assertThrows(DateTimeParseException.class, () -> {
-            formatter.format(null, ZoneId.of("UTC"));
-        });
-    }
-
-    @Test
-    void testGetDisplayPatterns() {
-        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
-                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
-                "TestConfig",
-                Locale.US
-        );
-
-        String expected = "yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd HH:mm:ss";
-        String result = formatter.getDisplayPatterns();
-        assertEquals(expected, result);
-    }
-
-    @Test
-void testFormatWithEmptyListOfDateStrings() {
-    MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
-            List.of(),
-            List.of(),
-            false
-    );
-
-    assertThrows(DateTimeParseException.class, () -> formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC")));
-}
-
-@Test
-void testFormatWithMultiplePatternsTargetingFirst() {
-    MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+  @Test
+  void testFormatWithValidDateString() {
+    MultiDateTimeFormatter formatter =
+        MultiDateTimeFormatter.createDateTimeFormatter(
             List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
             "TestConfig",
-            ZoneId.of("UTC")
-    );
+            ZoneId.of("UTC"));
 
     Instant expected = Instant.parse("2021-10-01T11:30:00Z");
     Instant result = formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC"));
     assertEquals(expected, result);
-}
+  }
 
-@Test
-void testFormatWithMultiplePatternsTargetingSecond() {
-    MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+  @Test
+  void testFormatWithInvalidDateString() {
+    MultiDateTimeFormatter formatter =
+        MultiDateTimeFormatter.createDateTimeFormatter(
             List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
             "TestConfig",
-            ZoneId.of("UTC")
-    );
+            ZoneId.of("UTC"));
+
+    assertThrows(
+        DateTimeParseException.class,
+        () -> {
+          formatter.format("invalid-date", ZoneId.of("UTC"));
+        });
+  }
+
+  @Test
+  void testFormatWithNullValueAndReturnNowIfNullTrue() {
+    MultiDateTimeFormatter formatter =
+        new MultiDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
+            true);
+
+    Instant result = formatter.format(null, ZoneId.of("UTC"));
+    assertNotNull(result);
+  }
+
+  @Test
+  void testFormatWithNullValueAndReturnNowIfNullFalse() {
+    MultiDateTimeFormatter formatter =
+        new MultiDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
+            false);
+
+    assertThrows(
+        DateTimeParseException.class,
+        () -> {
+          formatter.format(null, ZoneId.of("UTC"));
+        });
+  }
+
+  @Test
+  void testGetDisplayPatterns() {
+    MultiDateTimeFormatter formatter =
+        MultiDateTimeFormatter.createDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"), "TestConfig", Locale.US);
+
+    String expected = "yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd HH:mm:ss";
+    String result = formatter.getDisplayPatterns();
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatWithEmptyListOfDateStrings() {
+    MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(List.of(), List.of(), false);
+
+    assertThrows(
+        DateTimeParseException.class,
+        () -> formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC")));
+  }
+
+  @Test
+  void testFormatWithMultiplePatternsTargetingFirst() {
+    MultiDateTimeFormatter formatter =
+        MultiDateTimeFormatter.createDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            "TestConfig",
+            ZoneId.of("UTC"));
+
+    Instant expected = Instant.parse("2021-10-01T11:30:00Z");
+    Instant result = formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC"));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatWithMultiplePatternsTargetingSecond() {
+    MultiDateTimeFormatter formatter =
+        MultiDateTimeFormatter.createDateTimeFormatter(
+            List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+            "TestConfig",
+            ZoneId.of("UTC"));
 
     Instant expected = Instant.parse("2021-10-01T11:30:00Z");
     Instant result = formatter.format("2021-10-01 11:30:00", ZoneId.of("UTC"));
     assertEquals(expected, result);
-}
+  }
 }

--- a/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/MultiDateTimeFormatterTest.java
@@ -1,0 +1,77 @@
+package io.lenses.connect.smt.header;
+
+import org.junit.jupiter.api.Test;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Locale;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MultiDateTimeFormatterTest {
+
+    @Test
+    void testFormatWithValidDateString() {
+        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+                "TestConfig",
+                ZoneId.of("UTC")
+        );
+
+        Instant expected = Instant.parse("2021-10-01T11:30:00Z");
+        Instant result = formatter.format("2021-10-01T11:30:00", ZoneId.of("UTC"));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testFormatWithInvalidDateString() {
+        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+                "TestConfig",
+                ZoneId.of("UTC")
+        );
+
+        assertThrows(DateTimeParseException.class, () -> {
+            formatter.format("invalid-date", ZoneId.of("UTC"));
+        });
+    }
+
+    @Test
+    void testFormatWithNullValueAndReturnNowIfNullTrue() {
+        MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
+                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+                List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
+                true
+        );
+
+        Instant result = formatter.format(null, ZoneId.of("UTC"));
+        assertNotNull(result);
+    }
+
+    @Test
+    void testFormatWithNullValueAndReturnNowIfNullFalse() {
+        MultiDateTimeFormatter formatter = new MultiDateTimeFormatter(
+                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+                List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
+                false
+        );
+
+        assertThrows(DateTimeParseException.class, () -> {
+            formatter.format(null, ZoneId.of("UTC"));
+        });
+    }
+
+    @Test
+    void testGetDisplayPatterns() {
+        MultiDateTimeFormatter formatter = MultiDateTimeFormatter.createDateTimeFormatter(
+                List.of("yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss"),
+                "TestConfig",
+                Locale.US
+        );
+
+        String expected = "yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd HH:mm:ss";
+        String result = formatter.getDisplayPatterns();
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/io/lenses/connect/smt/header/PropsFormatterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/PropsFormatterTest.java
@@ -10,27 +10,26 @@
  */
 package io.lenses.connect.smt.header;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 class PropsFormatterTest {
 
-    @Test
-    void singleEntry() {
-        Map<String, Object> props = Map.of("something", "else");
-        PropsFormatter writer = new PropsFormatter(new SimpleConfig(new ConfigDef(), props));
-        assertEquals("{something: \"else\"}", writer.apply());
-    }
+  @Test
+  void singleEntry() {
+    Map<String, Object> props = Map.of("something", "else");
+    PropsFormatter writer = new PropsFormatter(new SimpleConfig(new ConfigDef(), props));
+    assertEquals("{something: \"else\"}", writer.apply());
+  }
 
-    @Test
-    void multipleEntries() {
-        Map<String, Object> props = Map.of("first", "item", "something", "else");
-        PropsFormatter writer = new PropsFormatter(new SimpleConfig(new ConfigDef(), props));
-        assertEquals("{first: \"item\", something: \"else\"}", writer.apply());
-    }
+  @Test
+  void multipleEntries() {
+    Map<String, Object> props = Map.of("first", "item", "something", "else");
+    PropsFormatter writer = new PropsFormatter(new SimpleConfig(new ConfigDef(), props));
+    assertEquals("{first: \"item\", something: \"else\"}", writer.apply());
+  }
 }

--- a/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
@@ -281,9 +281,8 @@ class TimestampConverterTest {
 
     String headerValue = (String) header.value();
     assertTrue(
-            headerValue.equals( "1970 01 01 18 00 01 234 CST") ||
-                    headerValue.equals( "1970 01 01 18 00 01 234 GMT-06:00")
-    );
+        headerValue.equals("1970 01 01 18 00 01 234 CST")
+            || headerValue.equals("1970 01 01 18 00 01 234 GMT-06:00"));
   }
 
   // Conversions without schemas (core types -> most flexible Timestamp format)

--- a/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/TimestampConverterTest.java
@@ -39,7 +39,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
 /** Test for {@link TimestampConverter}. */
-public class TimestampConverterTest {
+class TimestampConverterTest {
   private static final TimeZone UTC = Constants.UTC;
   private static final Calendar EPOCH;
   private static final Calendar TIME;
@@ -84,14 +84,14 @@ public class TimestampConverterTest {
   // Configuration
 
   @Test
-  public void testConfigNoTargetType() {
+  void testConfigNoTargetType() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     assertThrows(
         ConfigException.class, () -> transformer.configure(Collections.<String, String>emptyMap()));
   }
 
   @Test
-  public void testConfigInvalidTargetType() {
+  void testConfigInvalidTargetType() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     assertThrows(
         ConfigException.class,
@@ -101,7 +101,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigInvalidUnixPrecision() {
+  void testConfigInvalidUnixPrecision() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "invalid");
@@ -110,7 +110,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigValidUnixPrecision() {
+  void testConfigValidUnixPrecision() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "seconds");
@@ -120,7 +120,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigMissingFormat() {
+  void testConfigMissingFormat() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -129,7 +129,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testConfigInvalidFormat() {
+  void testConfigInvalidFormat() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, "bad-format");
@@ -141,7 +141,7 @@ public class TimestampConverterTest {
   // Conversions without schemas (most flexible Timestamp -> other types)
 
   @Test
-  public void testSchemalessIdentity() {
+  void testSchemalessIdentity() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -157,7 +157,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToDate() {
+  void testSchemalessTimestampToDate() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -173,7 +173,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToDateOnNonUTC() {
+  void testSchemalessTimestampToDateOnNonUTC() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -194,7 +194,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToTime() {
+  void testSchemalessTimestampToTime() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -210,7 +210,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToTimeNonUtc() {
+  void testSchemalessTimestampToTimeNonUtc() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -233,7 +233,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToUnix() {
+  void testSchemalessTimestampToUnix() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -249,7 +249,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToString() {
+  void testSchemalessTimestampToString() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, STRING_DATE_FMT);
@@ -265,12 +265,13 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimestampToStringTargeting() {
+  void testSchemalessTimestampToStringTargeting() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, STRING_DATE_FMT);
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "str_header");
     config.put(TimestampConverter.TARGET_TIMEZONE_CONFIG, "America/Chicago");
+
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     transformer.configure(config);
     SourceRecord transformed = transformer.apply(createRecordSchemaless(DATE_PLUS_TIME.getTime()));
@@ -278,13 +279,17 @@ public class TimestampConverterTest {
     Header header = transformed.headers().lastWithName("str_header");
     assertNotNull(header);
 
-    assertEquals("1970 01 01 18 00 01 234 CST", header.value());
+    String headerValue = (String) header.value();
+    assertTrue(
+            headerValue.equals( "1970 01 01 18 00 01 234 CST") ||
+                    headerValue.equals( "1970 01 01 18 00 01 234 GMT-06:00")
+    );
   }
 
   // Conversions without schemas (core types -> most flexible Timestamp format)
 
   @Test
-  public void testSchemalessDateToTimestamp() {
+  void testSchemalessDateToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -300,7 +305,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessTimeToTimestamp() {
+  void testSchemalessTimeToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -316,7 +321,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessUnixToTimestamp() {
+  void testSchemalessUnixToTimestamp() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -332,7 +337,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessUnixAsStringToTimestamp() {
+  void testSchemalessUnixAsStringToTimestamp() {
     TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -348,7 +353,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToTimestamp() {
+  void testSchemalessStringToTimestamp() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FORMAT_FROM_CONFIG, STRING_DATE_FMT);
@@ -366,7 +371,7 @@ public class TimestampConverterTest {
   // Conversions with schemas (most flexible Timestamp -> other types)
 
   @Test
-  public void testWithSchemaIdentity() {
+  void testWithSchemaIdentity() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -382,7 +387,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToDate() {
+  void testWithSchemaTimestampToDate() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
@@ -398,7 +403,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToTime() {
+  void testWithSchemaTimestampToTime() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Time");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "tm_header");
@@ -415,7 +420,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToUnix() {
+  void testWithSchemaTimestampToUnix() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "unix_header");
@@ -432,7 +437,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimestampToString() {
+  void testWithSchemaTimestampToString() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
     config.put(TimestampConverter.FORMAT_TO_CONFIG, STRING_DATE_FMT);
@@ -451,31 +456,31 @@ public class TimestampConverterTest {
   // Null-value conversions schemaless
 
   @Test
-  public void testSchemalessNullValueToString() {
+  void testSchemalessNullValueToString() {
     testSchemalessNullValueConversion("string");
     testSchemalessNullFieldConversion("string");
   }
 
   @Test
-  public void testSchemalessNullValueToDate() {
+  void testSchemalessNullValueToDate() {
     testSchemalessNullValueConversion("Date");
     testSchemalessNullFieldConversion("Date");
   }
 
   @Test
-  public void testSchemalessNullValueToTimestamp() {
+  void testSchemalessNullValueToTimestamp() {
     testSchemalessNullValueConversion("Timestamp");
     testSchemalessNullFieldConversion("Timestamp");
   }
 
   @Test
-  public void testSchemalessNullValueToUnix() {
+  void testSchemalessNullValueToUnix() {
     testSchemalessNullValueConversion("unix");
     testSchemalessNullFieldConversion("unix");
   }
 
   @Test
-  public void testSchemalessNullValueToTime() {
+  void testSchemalessNullValueToTime() {
     testSchemalessNullValueConversion("Time");
     testSchemalessNullFieldConversion("Time");
   }
@@ -514,7 +519,7 @@ public class TimestampConverterTest {
   // Conversions with schemas (core types -> most flexible Timestamp format)
 
   @Test
-  public void testWithSchemaDateToTimestamp() {
+  void testWithSchemaDateToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.HEADER_NAME_CONFIG, "ts_header");
@@ -531,7 +536,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaTimeToTimestamp() {
+  void testWithSchemaTimeToTimestamp() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -547,7 +552,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaUnixToTimestamp() {
+  void testWithSchemaUnixToTimestamp() {
     final TimestampConverter<SourceRecord> transformer = new TimestampConverter<>();
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
@@ -563,7 +568,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaStringToTimestamp() {
+  void testWithSchemaStringToTimestamp() {
     final Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FORMAT_FROM_CONFIG, STRING_DATE_FMT);
@@ -582,7 +587,7 @@ public class TimestampConverterTest {
   // Null-value conversions with schema
 
   @Test
-  public void testWithSchemaNullValueToTimestamp() {
+  void testWithSchemaNullValueToTimestamp() {
     testWithSchemaNullValueConversion(
         "Timestamp", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -602,7 +607,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToTimestamp() {
+  void testWithSchemaNullFieldToTimestamp() {
     testWithSchemaNullFieldConversion(
         "Timestamp", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -622,7 +627,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToUnix() {
+  void testWithSchemaNullValueToUnix() {
     testWithSchemaNullValueConversion(
         "unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -636,7 +641,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToUnix() {
+  void testWithSchemaNullFieldToUnix() {
     testWithSchemaNullFieldConversion(
         "unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -650,7 +655,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToTime() {
+  void testWithSchemaNullValueToTime() {
     testWithSchemaNullValueConversion(
         "Time", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -666,7 +671,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToTime() {
+  void testWithSchemaNullFieldToTime() {
     testWithSchemaNullFieldConversion(
         "Time", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -682,7 +687,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToDate() {
+  void testWithSchemaNullValueToDate() {
     testWithSchemaNullValueConversion(
         "Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -698,7 +703,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToDate() {
+  void testWithSchemaNullFieldToDate() {
     testWithSchemaNullFieldConversion(
         "Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -714,7 +719,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullValueToString() {
+  void testWithSchemaNullValueToString() {
     testWithSchemaNullValueConversion(
         "string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
     testWithSchemaNullValueConversion(
@@ -728,7 +733,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNullFieldToString() {
+  void testWithSchemaNullFieldToString() {
     testWithSchemaNullFieldConversion(
         "string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
     testWithSchemaNullFieldConversion(
@@ -794,7 +799,7 @@ public class TimestampConverterTest {
   // Convert field instead of entire key/value
 
   @Test
-  public void testSchemalessFieldConversion() {
+  void testSchemalessFieldConversion() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -812,7 +817,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion() {
+  void testWithSchemaFieldConversion() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -840,7 +845,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Micros() {
+  void testWithSchemaFieldConversion_Micros() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -865,7 +870,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Nanos() {
+  void testWithSchemaFieldConversion_Nanos() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -890,7 +895,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaFieldConversion_Seconds() {
+  void testWithSchemaFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "ts");
@@ -919,7 +924,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaValuePrefixedFieldConversion_Seconds() {
+  void testWithSchemaValuePrefixedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_value.ts");
@@ -948,7 +953,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithRecordMetadataPrefixedFieldConversion_Seconds() {
+  void testWithRecordMetadataPrefixedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_timestamp");
@@ -987,7 +992,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testRaiseExceptionIfTimestampMetadataIsUsedWithAPath() {
+  void testRaiseExceptionIfTimestampMetadataIsUsedWithAPath() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_timestamp.incorrect.path");
@@ -1008,7 +1013,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaKeyPrefixedFieldConversion_Seconds() {
+  void testWithSchemaKeyPrefixedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.ts");
@@ -1039,7 +1044,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedFieldConversion_Seconds() {
+  void testWithSchemaNestedFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "level1.ts");
@@ -1072,7 +1077,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion_Seconds() {
+  void testWithSchemaNestedKeyFieldConversion_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -1107,7 +1112,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Micros() {
+  void testSchemalessStringToUnix_Micros() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "microseconds");
@@ -1124,7 +1129,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Nanos() {
+  void testSchemalessStringToUnix_Nanos() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "nanoseconds");
@@ -1141,7 +1146,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testSchemalessStringToUnix_Seconds() {
+  void testSchemalessStringToUnix_Seconds() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "unix");
     config.put(TimestampConverter.UNIX_PRECISION_CONFIG, "seconds");
@@ -1160,7 +1165,7 @@ public class TimestampConverterTest {
   // Validate Key implementation in addition to Value
 
   @Test
-  public void testKey() {
+  void testKey() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key");
@@ -1178,7 +1183,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion15SecondsWindow() {
+  void testWithSchemaNestedKeyFieldConversion15SecondsWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -1216,7 +1221,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursTimestampWindow() {
+  void testWithSchemaNestedKeyFieldConversion2HoursTimestampWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");
@@ -1254,7 +1259,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursStringWindow() {
+  void testWithSchemaNestedKeyFieldConversion2HoursStringWindow() {
 
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
@@ -1296,7 +1301,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion2HoursStringWindowWhenSourceIsString() {
+  void testWithSchemaNestedKeyFieldConversion2HoursStringWindowWhenSourceIsString() {
 
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
@@ -1338,7 +1343,7 @@ public class TimestampConverterTest {
   }
 
   @Test
-  public void testWithSchemaNestedKeyFieldConversion10MinutesWindow() {
+  void testWithSchemaNestedKeyFieldConversion10MinutesWindow() {
     Map<String, String> config = new HashMap<>();
     config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
     config.put(TimestampConverter.FIELD_CONFIG, "_key.level1.ts");

--- a/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UtilsTimestampTest {
 
-    public static final String TIMESTAMP = "2024-08-16T04:30:00.232Z";
-    public static final String PRECISION = "milliseconds";
+    private static final String TIMESTAMP = "2024-08-16T04:30:00.232Z";
+    private static final String PRECISION = "milliseconds";
 
     @Test
     void convertToTimestampShouldWritePropsOnFailure() {
@@ -37,7 +37,7 @@ class UtilsTimestampTest {
                 ZoneId.of("UTC"),
                 Optional.of(propsFormatter)
         ));
-        assertEquals("Expected a long, but found 2024-08-16T04:30:00.232Z. Props: {some: \"props\", for: \"2\"}",dataException.getMessage());
+        assertEquals("Expected a long, but found 2024-08-16T04:30:00.232Z. Props: {for: \"2\", some: \"props\"}",dataException.getMessage());
     }
 
     @Test

--- a/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
@@ -10,46 +10,51 @@
  */
 package io.lenses.connect.smt.header;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 import org.junit.jupiter.api.Test;
 
-import java.time.ZoneId;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 class UtilsTimestampTest {
 
-    private static final String TIMESTAMP = "2024-08-16T04:30:00.232Z";
-    private static final String PRECISION = "milliseconds";
+  private static final String TIMESTAMP = "2024-08-16T04:30:00.232Z";
+  private static final String PRECISION = "milliseconds";
 
-    @Test
-    void convertToTimestampShouldWritePropsOnFailure() {
-        PropsFormatter propsFormatter = new PropsFormatter(new SimpleConfig(new ConfigDef(), Map.of("some", "props", "for", "2" ) ));
-        DataException dataException = assertThrows(DataException.class, () -> Utils.convertToTimestamp(
-                TIMESTAMP,
-                PRECISION,
-                Optional.empty(),
-                ZoneId.of("UTC"),
-                Optional.of(propsFormatter)
-        ));
-        assertEquals("Expected a long, but found 2024-08-16T04:30:00.232Z. Props: {for: \"2\", some: \"props\"}",dataException.getMessage());
-    }
+  @Test
+  void convertToTimestampShouldWritePropsOnFailure() {
+    PropsFormatter propsFormatter =
+        new PropsFormatter(new SimpleConfig(new ConfigDef(), Map.of("some", "props", "for", "2")));
+    DataException dataException =
+        assertThrows(
+            DataException.class,
+            () ->
+                Utils.convertToTimestamp(
+                    TIMESTAMP,
+                    PRECISION,
+                    Optional.empty(),
+                    ZoneId.of("UTC"),
+                    Optional.of(propsFormatter)));
+    assertEquals(
+        "Expected a long, but found 2024-08-16T04:30:00.232Z. Props: {for: \"2\", some: \"props\"}",
+        dataException.getMessage());
+  }
 
-    @Test
-    void convertToTimestampShouldNotFailWhenNoPropsFormatter() {
-        DataException dataException = assertThrows(DataException.class, () -> Utils.convertToTimestamp(
-                TIMESTAMP,
-                PRECISION,
-                Optional.empty(),
-                ZoneId.of("UTC"),
-                Optional.empty()
-        ));
-        assertEquals("Expected a long, but found 2024-08-16T04:30:00.232Z. Props: (No props formatter)",dataException.getMessage());
-    }
-
+  @Test
+  void convertToTimestampShouldNotFailWhenNoPropsFormatter() {
+    DataException dataException =
+        assertThrows(
+            DataException.class,
+            () ->
+                Utils.convertToTimestamp(
+                    TIMESTAMP, PRECISION, Optional.empty(), ZoneId.of("UTC"), Optional.empty()));
+    assertEquals(
+        "Expected a long, but found 2024-08-16T04:30:00.232Z. Props: (No props formatter)",
+        dataException.getMessage());
+  }
 }

--- a/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
+++ b/src/test/java/io/lenses/connect/smt/header/UtilsTimestampTest.java
@@ -46,7 +46,8 @@ class UtilsTimestampTest {
                 TIMESTAMP,
                 PRECISION,
                 Optional.empty(),
-                ZoneId.of("UTC")
+                ZoneId.of("UTC"),
+                Optional.empty()
         ));
         assertEquals("Expected a long, but found 2024-08-16T04:30:00.232Z. Props: (No props formatter)",dataException.getMessage());
     }


### PR DESCRIPTION
Adds support for multiple "from" patterns.

This converts the `format.from.pattern` field in the following SMTs:
- `InsertRollingFieldTimestampHeaders`
- `InsertRollingRecordTimestampHeaders`
- `InsertRollingWallclockHeaders`
- `TimestampConverter`

into a List (comma separated) so that these SMTs can support multiple (fallback) DateTimeFormatter patterns should multiple timestamps be in use.

This PR also cleans up some static analysis violations and fixes some intermittent tests, but no breaking changes.